### PR TITLE
Fix all ty check diagnostics (#17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,11 @@
 - run python commands with `uv run python ...`
 - **Lint**: `ruff check` (configured for line length 120, Python 3.13+)
 - **Format**: `ruff format`
-- **Type Check**: `ty check` (strict typing enabled)
+- **Type Check**: `ty check` (strict typing enabled). `scripts/` and `simulations/` are
+  type-checked with `unresolved-import` ignored — they import optional ML deps from
+  `[dependency-groups]` (`experiments`, `mlx`, `finetune`) that are not in the default
+  `.venv`. Install the relevant group with `uv sync --group <name>` before running such a
+  script.
 - **Run Tests**: `uv run pytest` (when implemented)
 - **Test Coverage**: Tests should be in `tests/` directory
 - use puppeteer to verify UI functionality

--- a/api/export.py
+++ b/api/export.py
@@ -113,7 +113,7 @@ class ExportService:
                 if "category_type" in df.columns:
                     group_cols.append("category_type")
 
-                agg_dict = {"amount": ["count", "sum", "mean"]}
+                agg_dict: dict[str, list[str] | str] = {"amount": ["count", "sum", "mean"]}
                 if "confidence_score" in df.columns:
                     agg_dict["confidence_score"] = "mean"
 

--- a/api/ml.py
+++ b/api/ml.py
@@ -622,7 +622,7 @@ async def repredict_unreviewed_transactions(
         al_predictions = []
         for txn, prediction in zip(repredict_txns, predictions, strict=True):
             al_pred = TransactionPrediction(
-                transaction_id=txn.id,
+                transaction_id=str(txn.id),
                 predicted_category_id=prediction.predicted_category_id,
                 confidence_score=prediction.confidence_score,
                 feature_contributions=prediction.feature_contributions,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,11 @@ unused-ignore-comment = "warn"
 # datetime.utcnow in SQLAlchemy Column defaults is acceptable pattern
 deprecated = "warn"
 
-# Exclude simulation notebooks and scripts from type checking
+# Relax type checking for experimental scripts and simulation notebooks.
+# These directories import optional ML deps (torch, sentence_transformers, transformers,
+# peft, mlx_lm, optuna, ...) declared in [dependency-groups] (experiments, mlx, finetune)
+# that are intentionally absent from the default .venv. Install with
+# `uv sync --group <name>` before running such a script.
 [[tool.ty.overrides]]
 include = ["simulations/", "scripts/"]
 
@@ -129,6 +133,8 @@ invalid-return-type = "ignore"
 invalid-assignment = "ignore"
 invalid-argument-type = "ignore"
 unresolved-reference = "ignore"
+unresolved-import = "ignore"
+not-subscriptable = "ignore"
 
 [tool.ty.terminal]
 output-format = "full"

--- a/scripts/experiment_finetune.py
+++ b/scripts/experiment_finetune.py
@@ -87,7 +87,7 @@ class TransactionDataset(Dataset):
     def __len__(self) -> int:
         return len(self.labels)
 
-    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:  # type: ignore[override]
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
         return {
             "input_ids": self.encodings["input_ids"][idx],
             "attention_mask": self.encodings["attention_mask"][idx],

--- a/src/fafycat/ml/categorizer.py
+++ b/src/fafycat/ml/categorizer.py
@@ -207,18 +207,19 @@ class TransactionCategorizer:
         text_features = X_df["text_combined"].fillna("").values
 
         if self._has_combined_vectorizer:
+            assert self.word_vectorizer is not None and self.svd is not None
             # Combined char + word TF-IDF → SVD (keeps sparse until SVD)
             if fit:
                 X_char = self.char_vectorizer.fit_transform(text_features)
-                X_word = self.word_vectorizer.fit_transform(text_features)  # type: ignore[union-attr]
+                X_word = self.word_vectorizer.fit_transform(text_features)
                 X_text_sparse = sparse_hstack([X_char, X_word])
-                X_text = self.svd.fit_transform(X_text_sparse)  # type: ignore[union-attr]
+                X_text = self.svd.fit_transform(X_text_sparse)
                 self.feature_names = numerical_features + [f"svd_{i}" for i in range(X_text.shape[1])]
             else:
                 X_char = self.char_vectorizer.transform(text_features)
-                X_word = self.word_vectorizer.transform(text_features)  # type: ignore[union-attr]
+                X_word = self.word_vectorizer.transform(text_features)
                 X_text_sparse = sparse_hstack([X_char, X_word])
-                X_text = self.svd.transform(X_text_sparse)  # type: ignore[union-attr]
+                X_text = self.svd.transform(X_text_sparse)
         else:
             # Legacy single-vectorizer path (for old saved models)
             if fit:

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
-[options]
-exclude-newer = "2026-04-01T07:03:45.552819Z"
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "accelerate"
 version = "1.12.0"


### PR DESCRIPTION
Closes #17.

## Summary
Achieve zero-diagnostic `ty check` (verified against `uvx ty` 0.0.29, the version run by the precommit hook).

## Config
- Extend the existing `scripts/` + `simulations/` `[[tool.ty.overrides]]` block to also ignore `unresolved-import` and `not-subscriptable`. These dirs import optional ML deps (`torch`, `sentence_transformers`, `transformers`, `peft`, `mlx_lm`, `mlx.core`, `optuna`) declared in `[dependency-groups]` (`experiments`, `mlx`, `finetune`) that are intentionally absent from the default `.venv`.
- Drop the now-unused `# type: ignore[override]` in `scripts/experiment_finetune.py`.

## Source fixes (latent errors surfaced once warnings cleared)
- `api/export.py`: widen `agg_dict` annotation to `dict[str, list[str] | str]` so the `'mean'` assignment type-checks.
- `api/ml.py`: wrap `txn.id` in `str()` so it satisfies `TransactionPrediction.transaction_id: str` (SQLAlchemy column coercion).
- `src/fafycat/ml/categorizer.py`: replace mypy-style `# type: ignore[union-attr]` comments on `word_vectorizer`/`svd` accesses with an `assert` that narrows the `Optional` types after the `_has_combined_vectorizer` guard. ty doesn't honour mypy ignore codes; the assert documents the invariant clearly and works for both checkers.

## Docs
- `CLAUDE.md`: document that `scripts/` and `simulations/` may import optional ML deps and how to install the relevant group with `uv sync --group <name>` before running such a script.

## Reviewer notes
- The original issue listed only the unresolved-import warnings, but the precommit hook (which uses a newer `uvx ty` than `uv run ty`) also surfaces several pre-existing `error`-severity diagnostics in `api/` and `src/fafycat/ml/`. Per discussion, scope was expanded to clear those too so the acceptance criterion ("`ty check` passes with no warnings") is genuinely met.
- No behavioural change in the source fixes — `assert` mirrors the runtime invariant the property already guarantees, `str(txn.id)` is a no-op at runtime for str values, and `agg_dict` was already mixing `list[str]` and `str` values.

## Test plan
- [x] `uvx ty check` → `All checks passed!`
- [x] `uvx ruff check` → All checks passed
- [x] precommit hook (ruff-check, ruff-format, ty-check) green on commit
- [ ] CI green