### PR TITLE
[codex] Update urllib3 for Dependabot alerts

### DIFF
--- a/scripts/capture_readme_demo.sh
+++ b/scripts/capture_readme_demo.sh
@@ -83,8 +83,8 @@ for _ in range(90):
 raise SystemExit("Training did not complete in time")
 PY
 
-npm install --prefix "${NODE_TOOLS_DIR}" --no-save --no-package-lock playwright >/dev/null
-NODE_PATH="${NODE_TOOLS_DIR}/node_modules" npx -y playwright install chromium >/dev/null
+npm install --prefix "${NODE_TOOLS_DIR}" --ignore-scripts --no-save --no-package-lock playwright >/dev/null
+NODE_PATH="${NODE_TOOLS_DIR}/node_modules" "${NODE_TOOLS_DIR}/node_modules/.bin/playwright" install chromium >/dev/null
 NODE_PATH="${NODE_TOOLS_DIR}/node_modules" node "${ROOT_DIR}/scripts/capture_readme_demo.cjs" \
     --base-url "${BASE_URL}" \
     --output-dir "${RAW_DIR}" \

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-16T00:15:41.586572Z"
 exclude-newer-span = "P1D"
 
 [[package]]
@@ -3137,11 +3137,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates the locked transitive `urllib3` dependency from 2.6.3 to 2.7.0.

Addresses the two open high-severity Dependabot alerts on `uv.lock`:

- #40 / GHSA-mf9v-mfxr-j63j / CVE-2026-44432: decompression-bomb safeguards bypass in parts of the streaming API
- #41 / GHSA-qccp-gfcp-xxvc / CVE-2026-44431: sensitive headers forwarded across origins in proxied low-level redirects

Also hardens the only npm-using helper script by installing Playwright with `--ignore-scripts` and invoking the local Playwright binary instead of `npx -y`.

## Shai-Hulud compromise checks

Checked the repo against the May 2026 public indicators for Mini Shai-Hulud npm and PyPI campaigns.

npm/TanStack indicators:

- no tracked Node dependency manifests or lockfiles (`package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`)
- no affected package namespace/package markers found (`@tanstack`, `@squawk`, `@uipath`, `@mistralai`, etc.)
- no payload/dependency markers found (`router_init.js`, `router_runtime.js`, `tanstack_runner.js`, `@tanstack/setup`, `github:tanstack/router#79ac49...`)
- GitHub Actions workflow is Python-only, has `contents: read`, and does not publish npm packages or request OIDC/npm publish privileges

PyPI indicators:

- `uv.lock` and `pyproject.toml` do not include the reported compromised packages/versions: `lightning==2.6.2`, `lightning==2.6.3`, `mistralai==2.4.6`, or `guardrails-ai==0.10.1`
- `uv tree --locked --all-groups` confirms all dependency groups resolve without those packages
- local `.venv` metadata check shows `lightning`, `pytorch-lightning`, `mistralai`, `guardrails-ai`, and `opensearch-py` are not installed
- no PyPI payload markers found (`transformers.pyz`, `_runtime/start.py`, `router_runtime.js`, `git-tanstack`, `83.142.209.194`, Shai-Hulud strings)

## Validation

- `pre-commit run --all-files`
- `uv run pytest`
- `uv build`
- pre-push hook during `git push`