### PR TITLE
fix: audit findings — cross-year analytics, temp file leak, N+1 query

### DIFF
--- a/src/fafycat/api/services.py
+++ b/src/fafycat/api/services.py
@@ -1,6 +1,7 @@
 """Service layer for database operations."""
 
 import math
+import statistics
 from datetime import date, datetime
 from typing import Any, cast
 
@@ -619,7 +620,7 @@ class AnalyticsService:
         """Query monthly transaction aggregations by category type."""
         query = (
             session.query(
-                func.strftime("%m", TransactionORM.date).label("month"),
+                func.strftime("%Y-%m", TransactionORM.date).label("month"),
                 CategoryORM.type,
                 func.sum(TransactionORM.amount).label("total_amount"),
             )
@@ -629,8 +630,8 @@ class AnalyticsService:
             )
             .filter(TransactionORM.date.between(start_date, end_date))
             .filter(or_(TransactionORM.category_id.is_not(None), TransactionORM.predicted_category_id.is_not(None)))
-            .group_by(func.strftime("%m", TransactionORM.date), CategoryORM.type)
-            .order_by(func.strftime("%m", TransactionORM.date))
+            .group_by(func.strftime("%Y-%m", TransactionORM.date), CategoryORM.type)
+            .order_by(func.strftime("%Y-%m", TransactionORM.date))
         )
         return query.all()
 
@@ -642,7 +643,8 @@ class AnalyticsService:
         end_month = end_date.replace(day=1)
 
         while current_date <= end_month:
-            month_str = f"{current_date.month:02d}"
+            # Year-qualified key so multi-year ranges don't collapse same-named months
+            month_str = f"{current_date.year}-{current_date.month:02d}"
             monthly_data[month_str] = {
                 "month": month_str,
                 "income": 0.0,
@@ -790,7 +792,7 @@ class AnalyticsService:
         # Use COALESCE to get effective category (actual takes precedence over predicted)
         query = (
             session.query(
-                func.strftime("%m", TransactionORM.date).label("month"),
+                func.strftime("%Y-%m", TransactionORM.date).label("month"),
                 func.sum(TransactionORM.amount).label("savings_amount"),
             )
             .join(
@@ -800,8 +802,8 @@ class AnalyticsService:
             .filter(CategoryORM.type == CategoryType.SAVING)
             .filter(TransactionORM.date.between(resolved_start, resolved_end))
             .filter(or_(TransactionORM.category_id.is_not(None), TransactionORM.predicted_category_id.is_not(None)))
-            .group_by(func.strftime("%m", TransactionORM.date))
-            .order_by(func.strftime("%m", TransactionORM.date))
+            .group_by(func.strftime("%Y-%m", TransactionORM.date))
+            .order_by(func.strftime("%Y-%m", TransactionORM.date))
         )
 
         results = query.all()
@@ -814,7 +816,8 @@ class AnalyticsService:
         end_month = resolved_end.replace(day=1)
 
         while current_date <= end_month:
-            month_str = f"{current_date.month:02d}"
+            # Year-qualified key so multi-year ranges don't collapse same-named months
+            month_str = f"{current_date.year}-{current_date.month:02d}"
             monthly_savings[month_str] = {"month": month_str, "amount": 0.0}
             # Move to next month
             if current_date.month == 12:
@@ -840,7 +843,7 @@ class AnalyticsService:
         stats = {
             "total_savings": cumulative_savings,
             "average_monthly": sum(amounts) / len(amounts) if amounts else 0,
-            "median_monthly": sorted(amounts)[len(amounts) // 2] if amounts else 0,
+            "median_monthly": statistics.median(amounts) if amounts else 0,
             "months_with_savings": len(amounts),
         }
 
@@ -1128,11 +1131,7 @@ class AnalyticsService:
     ) -> dict[str, Any]:
         """Get monthly cumulative data for a specific category across multiple years."""
         if not years:
-            year_query = session.query(func.distinct(func.strftime("%Y", TransactionORM.date))).order_by(
-                func.strftime("%Y", TransactionORM.date).desc()
-            )
-            available_years = [int(y[0]) for y in year_query.all()]
-            years = available_years[:3] if len(available_years) >= 3 else available_years
+            years = AnalyticsService._get_available_years(session)
 
         if not years:
             return {"years": [], "monthly_data": {}, "category_name": None}
@@ -1241,18 +1240,19 @@ class BudgetService:
     @staticmethod
     def get_budgets_for_year(session: Session, year: int) -> dict[str, Any]:
         """Get all budgets for a specific year."""
-        # Get all active categories
-        categories = session.query(CategoryORM).filter(CategoryORM.is_active).all()
+        # Fetch categories and their year-specific budgets in one query (avoids N+1)
+        rows = (
+            session.query(CategoryORM, BudgetPlanORM)
+            .outerjoin(
+                BudgetPlanORM,
+                and_(BudgetPlanORM.category_id == CategoryORM.id, BudgetPlanORM.year == year),
+            )
+            .filter(CategoryORM.is_active)
+            .all()
+        )
 
         budgets = []
-        for category in categories:
-            # Try to get year-specific budget
-            budget_plan = (
-                session.query(BudgetPlanORM)
-                .filter(BudgetPlanORM.category_id == category.id, BudgetPlanORM.year == year)
-                .first()
-            )
-
+        for category, budget_plan in rows:
             if budget_plan:
                 budget = _to_float(budget_plan.monthly_budget)
                 has_year_specific = True
@@ -1275,7 +1275,7 @@ class BudgetService:
         return {
             "year": year,
             "budgets": budgets,
-            "total_categories": len(categories),
+            "total_categories": len(budgets),
             "has_year_specific_budgets": has_year_specific_budgets,
         }
 

--- a/src/fafycat/api/upload.py
+++ b/src/fafycat/api/upload.py
@@ -173,6 +173,7 @@ async def upload_csv(file: UploadFile = File(...), db: Session = Depends(get_db_
     if file.size and file.size > 10 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="File too large (max 10MB)")
 
+    temp_file_path: Path | None = None
     try:
         # Create temporary file
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".csv", delete=False) as temp_file:
@@ -183,9 +184,6 @@ async def upload_csv(file: UploadFile = File(...), db: Session = Depends(get_db_
         # Process CSV
         processor = CSVProcessor(db)
         transactions, errors = processor.import_csv(temp_file_path)
-
-        # Clean up temp file
-        temp_file_path.unlink()
 
         if errors:
             raise HTTPException(
@@ -227,6 +225,9 @@ async def upload_csv(file: UploadFile = File(...), db: Session = Depends(get_db_
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Upload processing failed: {str(e)}") from e
+    finally:
+        if temp_file_path is not None:
+            temp_file_path.unlink(missing_ok=True)
 
 
 @router.get("/preview/{upload_id}")
@@ -294,6 +295,7 @@ async def confirm_upload(upload_id: str, db: Session = Depends(get_db_session)) 
 @router.post("/csv-htmx", response_class=HTMLResponse)
 async def upload_csv_htmx(file: UploadFile = File(...), db: Session = Depends(get_db_session)) -> str:
     """Upload and process a CSV file, returning HTML results for HTMX."""
+    temp_file_path: Path | None = None
     try:
         # Validate file type
         if not file.filename or not file.filename.endswith(".csv"):
@@ -312,9 +314,6 @@ async def upload_csv_htmx(file: UploadFile = File(...), db: Session = Depends(ge
         # Process CSV
         processor = CSVProcessor(db)
         transactions, errors = processor.import_csv(temp_file_path)
-
-        # Clean up temp file
-        temp_file_path.unlink()
 
         if errors:
             return _render_upload_error(f"CSV processing errors: {'; '.join(errors[:3])}")
@@ -339,6 +338,9 @@ async def upload_csv_htmx(file: UploadFile = File(...), db: Session = Depends(ge
 
     except Exception as e:
         return _render_upload_error(f"Upload processing failed: {str(e)}")
+    finally:
+        if temp_file_path is not None:
+            temp_file_path.unlink(missing_ok=True)
 
 
 def _render_upload_success(

--- a/src/fafycat/cli.py
+++ b/src/fafycat/cli.py
@@ -598,11 +598,11 @@ def _dispatch_group(
     handlers: dict[str, Callable[[argparse.Namespace], None]],
 ) -> None:
     """Dispatch to a named subcommand handler, or print group help if none given."""
-    subcommand = getattr(args, "subcommand", None)
-    if subcommand is None:
+    raw_subcommand = getattr(args, "subcommand", None)
+    if raw_subcommand is None:
         group_parser.print_help()
         sys.exit(0)
-    handler = handlers.get(subcommand)
+    handler = handlers.get(str(raw_subcommand))
     if handler is not None:
         handler(args)
 

--- a/src/fafycat/core/database.py
+++ b/src/fafycat/core/database.py
@@ -99,6 +99,7 @@ class TransactionORM(Base):
         CheckConstraint("confidence_score >= 0 AND confidence_score <= 1", name="check_confidence_range"),
         Index("idx_transactions_date", "date"),
         Index("idx_transactions_category", "category_id"),
+        Index("idx_transactions_predicted_category", "predicted_category_id"),
         Index("idx_transactions_reviewed", "is_reviewed"),
         Index("idx_transactions_confidence", "confidence_score"),
         Index("idx_transactions_amount", "amount"),
@@ -172,8 +173,17 @@ class DatabaseManager:
         self.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
 
     def create_tables(self) -> None:
-        """Create all database tables."""
+        """Create all database tables and any indexes missing from existing tables.
+
+        ``create_all`` skips tables that already exist, so indexes added to the
+        schema after a database was created are built explicitly here.
+        """
         Base.metadata.create_all(bind=self.engine)
+        with self.engine.connect() as conn:
+            for table in Base.metadata.tables.values():
+                for index in table.indexes:
+                    index.create(bind=conn, checkfirst=True)
+            conn.commit()
 
     def get_session(self) -> Session:
         """Get database session."""

--- a/src/fafycat/ml/active_learning.py
+++ b/src/fafycat/ml/active_learning.py
@@ -135,8 +135,10 @@ class ActiveLearningSelector:
 
     def _get_merchant_novelty_score(self, merchant_name: str) -> float:
         """Calculate novelty score for merchant (higher for new/rare merchants)."""
-        # Count how many transactions we have from this merchant
-        count = self.session.query(TransactionORM).filter(TransactionORM.name.like(f"%{merchant_name[:10]}%")).count()
+        # Count how many transactions we have from this merchant.
+        # Escape LIKE wildcards so merchant names containing % or _ match literally.
+        prefix = merchant_name[:10].replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        count = self.session.query(TransactionORM).filter(TransactionORM.name.like(f"%{prefix}%", escape="\\")).count()
 
         # Novelty decreases with frequency
         if count == 0:

--- a/src/fafycat/static/js/analytics.js
+++ b/src/fafycat/static/js/analytics.js
@@ -105,6 +105,19 @@ function formatDateRange(startDate, endDate, year) {
 }
 
 /**
+ * Format a "YYYY-MM" month key as a chart label.
+ * Shows "Jan" for single-year data, "Jan 24" when the dataset spans years.
+ */
+function formatMonthLabel(monthKey, dataset) {
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const [year, month] = String(monthKey).split('-');
+    const name = monthNames[parseInt(month, 10) - 1] || monthKey;
+    const multiYear = new Set(dataset.map(d => String(d.month).split('-')[0])).size > 1;
+    return multiYear ? `${name} ${year.slice(2)}` : name;
+}
+
+/**
  * Initialize or update budget variance chart
  */
 function updateBudgetVarianceChart(data) {
@@ -213,12 +226,8 @@ function updateMonthlyOverviewChart(data) {
     const monthlyData = data.monthly_data || [];
     const dateRange = formatDateRange(data.start_date, data.end_date, data.year);
 
-    // Prepare chart data
-    const labels = monthlyData.map(m => {
-        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                           'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-        return monthNames[parseInt(m.month) - 1];
-    });
+    // Prepare chart data ("month" is "YYYY-MM"; show year only for multi-year ranges)
+    const labels = monthlyData.map(m => formatMonthLabel(m.month, monthlyData));
 
     charts.monthlyOverview = new Chart(ctx, {
         type: 'bar',
@@ -703,11 +712,7 @@ function updateSavingsTrackingChart(data) {
         monthlyValues = [0];
         cumulativeValues = [0];
     } else {
-        labels = savingsData.map(s => {
-            const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                               'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-            return monthNames[parseInt(s.month) - 1];
-        });
+        labels = savingsData.map(s => formatMonthLabel(s.month, savingsData));
         monthlyValues = savingsData.map(s => Math.abs(s.amount));
         cumulativeValues = savingsData.map(s => s.cumulative_amount);
     }

--- a/src/fafycat/web/pages/settings_page.py
+++ b/src/fafycat/web/pages/settings_page.py
@@ -92,9 +92,9 @@ def render_settings_page(request: Request, db: Session):
     """Render the settings and categories page."""
 
     # Get all categories (including inactive ones for management)
-    active_categories = get_categories(db, active_only=True)
-    inactive_categories = get_categories(db, active_only=False)
-    inactive_categories = [cat for cat in inactive_categories if not cat.is_active]
+    all_categories = get_categories(db, active_only=False)
+    active_categories = [cat for cat in all_categories if cat.is_active]
+    inactive_categories = [cat for cat in all_categories if not cat.is_active]
 
     # Group categories by type
     category_groups = {

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -342,3 +342,37 @@ class TestAvailableYearsEndpoint:
         data = response.json()
         assert data["latest_transaction_date"] == "2024-12-15"
         assert data["default_year"] == 2024
+
+
+class TestMonthlySummaryAPI:
+    """Tests for the monthly summary endpoint."""
+
+    def test_single_year_returns_twelve_months(self, test_client):
+        """Test that a year-based query returns one entry per month."""
+        response = test_client.get("/api/analytics/monthly-summary?year=2024")
+        assert response.status_code == 200
+
+        data = response.json()
+        monthly_data = data["monthly_data"]
+        assert len(monthly_data) == 12
+        assert [m["month"] for m in monthly_data] == [f"2024-{month:02d}" for month in range(1, 13)]
+
+    def test_cross_year_range_keeps_months_separate(self, test_client):
+        """Test that a range spanning years does not merge same-named months.
+
+        Regression test: months used to be keyed by month number only, so
+        January 2023 and January 2024 were summed into a single bucket.
+        """
+        response = test_client.get("/api/analytics/monthly-summary?start_date=2023-11-01&end_date=2024-02-28")
+        assert response.status_code == 200
+
+        data = response.json()
+        monthly_data = {m["month"]: m for m in data["monthly_data"]}
+        assert sorted(monthly_data) == ["2023-11", "2023-12", "2024-01", "2024-02"]
+
+        # 2024 salary is 3150/month; a collapsed bucket would show 3000 + 3150
+        assert monthly_data["2024-01"]["income"] == pytest.approx(3150.00)
+        assert monthly_data["2023-11"]["income"] == pytest.approx(3000.00)
+
+        # Yearly totals cover exactly the four months in range
+        assert data["yearly_totals"]["income"] == pytest.approx(2 * 3000.00 + 2 * 3150.00)


### PR DESCRIPTION
## Summary

Codebase audit fixes. Each finding verified against the code before implementing; two reported findings were rejected as false positives.

### Bug fixes
- **Cross-year analytics (high):** monthly summary and savings tracking grouped by month number only (`strftime('%m')`), so date ranges spanning years merged same-named months (e.g. Jan of two different years) into a single bucket. Now keyed by `YYYY-MM`; chart labels show a year suffix only when the range spans years. Regression tests added.
- **Temp file leak:** both CSV upload handlers skipped temp file cleanup when import raised. Cleanup moved to `finally`.
- **Wrong median:** savings statistics took the upper-middle element for even-length lists; now uses `statistics.median`.
- **LIKE wildcard escaping:** merchant novelty lookup left `%`/`_` unescaped in the pattern (bound parameter, so no injection — but match semantics broke for names containing wildcards).

### Performance
- **N+1 query:** `get_budgets_for_year` ran one budget query per category; now a single outer join (safe — unique constraint on `category_id, year`).
- **Missing index:** `transactions.predicted_category_id` is filtered in 7 places but had no index. Added, and `create_tables` now builds indexes missing from existing databases (`create_all` alone skips existing tables).
- Removed duplicate category query on settings page and duplicate available-years query in cumulative analytics.

### Hygiene
- Fixed the last `ty` diagnostic (CLI subcommand dispatch) — type check now clean.

### Rejected findings
- `html.escape(json.dumps(...))` "double-escape" — correct for JS-in-HTML-attribute context.
- Removing `_to_*` cast helpers — 63 call sites, churn outweighs value.

## Test plan
- [x] ruff + ty clean, 260 tests pass (2 new regression tests for cross-year bucketing)
- [x] Live dev server: cross-year range returns distinct `YYYY-MM` months; budgets endpoint intact
- [x] Startup backfills new index on an existing database
- [x] Puppeteer: all 7 analytics charts render, labels correct, zero JS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)