### PR TITLE
Prediction Pipeline: one owner for prediction, selection, and review priority

### DIFF
--- a/src/fafycat/api/ml.py
+++ b/src/fafycat/api/ml.py
@@ -2,8 +2,6 @@
 
 import asyncio
 import time
-from datetime import date
-from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -32,7 +30,7 @@ from fafycat.core.database import AppSettingsORM, CategoryORM
 from fafycat.core.models import TransactionInput
 from fafycat.ml.categorizer import TransactionCategorizer
 from fafycat.ml.ensemble_categorizer import EnsembleCategorizer
-from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted
+from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted, repredict_unreviewed
 
 router = APIRouter(prefix="/ml", tags=["ml"])
 
@@ -490,107 +488,23 @@ async def repredict_unreviewed_transactions(
 ) -> dict:
     """Re-run ML predictions on unreviewed transactions that already have predictions."""
     try:
-        from fafycat.core.database import TransactionORM
-        from fafycat.core.models import TransactionInput
+        summary, remaining = repredict_unreviewed(db, categorizer, limit=limit)
 
-        # Get unreviewed transactions that already have predictions
-        repredict_txns = (
-            db.query(TransactionORM)
-            .filter(
-                TransactionORM.is_reviewed.is_(False),
-                TransactionORM.predicted_category_id.is_not(None),
-            )
-            .limit(limit)
-            .all()
-        )
-
-        if not repredict_txns:
+        if summary.total == 0:
             return {
                 "status": "success",
                 "message": "No unreviewed transactions need re-prediction",
                 "predictions_made": 0,
             }
 
-        # Convert to TransactionInput for prediction
-        txn_inputs = []
-        for txn in repredict_txns:
-            txn_input = TransactionInput(
-                date=cast(date, txn.date),
-                value_date=cast(date, txn.value_date or txn.date),
-                name=str(txn.name),
-                purpose=str(txn.purpose or ""),
-                amount=cast(float, txn.amount),
-                currency=str(txn.currency),
-            )
-            txn_inputs.append(txn_input)
-
-        # Get predictions
-        predictions = categorizer.predict_with_confidence(txn_inputs)
-
-        # Use active learning to set review priorities
-        from fafycat.core.models import TransactionPrediction
-        from fafycat.ml.active_learning import ActiveLearningSelector
-
-        al_selector = ActiveLearningSelector(db)
-
-        # Convert predictions to TransactionPrediction format for active learning
-        al_predictions = []
-        for txn, prediction in zip(repredict_txns, predictions, strict=True):
-            al_pred = TransactionPrediction(
-                transaction_id=str(txn.id),
-                predicted_category_id=prediction.predicted_category_id,
-                confidence_score=prediction.confidence_score,
-                feature_contributions=prediction.feature_contributions,
-            )
-            al_predictions.append(al_pred)
-
-        # Get active learning strategic selections
-        max_review_items = min(20, len(al_predictions))
-        strategic_selections = set(
-            al_selector.select_for_review(al_predictions, max_items=max_review_items, strategy="uncertainty")
-        )
-
-        # Apply hybrid categorization: confidence + active learning priority
-        predictions_made = 0
-        auto_accepted = 0
-        high_priority_review = 0
-        standard_review = 0
-        confidence_threshold = get_auto_approve_threshold(db)
-
-        for txn, prediction in zip(repredict_txns, predictions, strict=True):
-            txn.predicted_category_id = prediction.predicted_category_id
-            txn.confidence_score = prediction.confidence_score
-
-            if prediction.confidence_score >= confidence_threshold:
-                if txn.id in strategic_selections:
-                    txn.is_reviewed = False
-                    txn.review_priority = "quality_check"
-                    high_priority_review += 1
-                else:
-                    txn.is_reviewed = True
-                    txn.review_priority = "auto_accepted"
-                    auto_accepted += 1
-            else:
-                txn.is_reviewed = False
-                if txn.id in strategic_selections:
-                    txn.review_priority = "high"
-                    high_priority_review += 1
-                else:
-                    txn.review_priority = "standard"
-                    standard_review += 1
-
-            predictions_made += 1
-
-        db.commit()
-
         return {
             "status": "success",
-            "message": f"Re-predicted {predictions_made} transactions",
-            "predictions_made": predictions_made,
-            "auto_accepted": auto_accepted,
-            "high_priority_review": high_priority_review,
-            "standard_review": standard_review,
-            "remaining_unreviewed": max(0, len(repredict_txns) - limit) if len(repredict_txns) == limit else 0,
+            "message": f"Re-predicted {summary.total} transactions",
+            "predictions_made": summary.total,
+            "auto_accepted": summary.auto_accepted,
+            "high_priority_review": summary.quality_check + summary.high,
+            "standard_review": summary.standard,
+            "remaining_unreviewed": remaining,
         }
 
     except Exception as e:

--- a/src/fafycat/api/ml.py
+++ b/src/fafycat/api/ml.py
@@ -32,6 +32,7 @@ from fafycat.core.database import AppSettingsORM, CategoryORM
 from fafycat.core.models import TransactionInput
 from fafycat.ml.categorizer import TransactionCategorizer
 from fafycat.ml.ensemble_categorizer import EnsembleCategorizer
+from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted
 
 router = APIRouter(prefix="/ml", tags=["ml"])
 
@@ -101,17 +102,6 @@ def get_categorizer(db: Session = Depends(get_db_session)) -> TransactionCategor
             )
 
     return _categorizer
-
-
-def get_auto_approve_threshold(db: Session) -> float:
-    """Read auto_approve_threshold from DB, falling back to MLConfig default."""
-    try:
-        setting = db.query(AppSettingsORM).filter(AppSettingsORM.key == "auto_approve_threshold").first()
-        if setting and setting.value is not None:
-            return float(str(setting.value))
-    except Exception:
-        pass
-    return AppConfig().ml.auto_approve_threshold
 
 
 @router.get("/settings")
@@ -469,109 +459,23 @@ async def predict_unpredicted_transactions(
 ) -> dict:
     """Run ML predictions on transactions that don't have predictions yet."""
     try:
-        from fafycat.core.database import TransactionORM
-        from fafycat.core.models import TransactionInput
+        summary, remaining = predict_unpredicted(db, categorizer, limit=limit)
 
-        # Get transactions without predictions
-        try:
-            unpredicted_txns = (
-                db.query(TransactionORM).filter(TransactionORM.predicted_category_id.is_(None)).limit(limit).all()
-            )
-        except Exception:
-            # Handle case where transactions table doesn't exist (e.g., in tests)
-            unpredicted_txns = []
-
-        if not unpredicted_txns:
+        if summary.total == 0:
             return {
                 "status": "success",
                 "message": "No transactions need prediction",
                 "predictions_made": 0,
             }
 
-        # Convert to TransactionInput for prediction
-        txn_inputs = []
-        for txn in unpredicted_txns:
-            txn_input = TransactionInput(
-                date=cast(date, txn.date),
-                value_date=cast(date, txn.value_date or txn.date),
-                name=str(txn.name),
-                purpose=str(txn.purpose or ""),
-                amount=cast(float, txn.amount),
-                currency=str(txn.currency),
-            )
-            txn_inputs.append(txn_input)
-
-        # Get predictions
-        predictions = categorizer.predict_with_confidence(txn_inputs)
-
-        # Use active learning to set review priorities (same logic as upload)
-        from fafycat.core.models import TransactionPrediction
-        from fafycat.ml.active_learning import ActiveLearningSelector
-
-        al_selector = ActiveLearningSelector(db)
-
-        # Convert predictions to TransactionPrediction format for active learning
-        al_predictions = []
-        for txn, prediction in zip(unpredicted_txns, predictions, strict=True):
-            al_pred = TransactionPrediction(
-                transaction_id=txn.id,
-                predicted_category_id=prediction.predicted_category_id,
-                confidence_score=prediction.confidence_score,
-                feature_contributions=prediction.feature_contributions,
-            )
-            al_predictions.append(al_pred)
-
-        # Get active learning strategic selections
-        max_review_items = min(20, len(al_predictions))  # Limit to 20 strategic selections
-        strategic_selections = set(
-            al_selector.select_for_review(al_predictions, max_items=max_review_items, strategy="uncertainty")
-        )
-
-        # Apply hybrid categorization: confidence + active learning priority
-        predictions_made = 0
-        auto_accepted = 0
-        high_priority_review = 0
-        standard_review = 0
-        confidence_threshold = get_auto_approve_threshold(db)
-
-        for txn, prediction in zip(unpredicted_txns, predictions, strict=True):
-            txn.predicted_category_id = prediction.predicted_category_id
-            txn.confidence_score = prediction.confidence_score
-
-            if prediction.confidence_score >= confidence_threshold:
-                # High confidence - check if active learning flagged it for quality validation
-                if txn.id in strategic_selections:
-                    # High confidence but flagged for quality check
-                    txn.is_reviewed = False
-                    txn.review_priority = "quality_check"
-                    high_priority_review += 1
-                else:
-                    # High confidence and not flagged - auto accept
-                    txn.is_reviewed = True
-                    txn.review_priority = "auto_accepted"
-                    auto_accepted += 1
-            else:
-                # Lower confidence - definitely needs review
-                txn.is_reviewed = False
-                if txn.id in strategic_selections:
-                    txn.review_priority = "high"
-                    high_priority_review += 1
-                else:
-                    txn.review_priority = "standard"
-                    standard_review += 1
-
-            predictions_made += 1
-
-        db.commit()
-
         return {
             "status": "success",
-            "message": f"Made predictions for {predictions_made} transactions",
-            "predictions_made": predictions_made,
-            "auto_accepted": auto_accepted,
-            "high_priority_review": high_priority_review,
-            "standard_review": standard_review,
-            "remaining_unpredicted": max(0, len(unpredicted_txns) - limit) if len(unpredicted_txns) == limit else 0,
+            "message": f"Made predictions for {summary.total} transactions",
+            "predictions_made": summary.total,
+            "auto_accepted": summary.auto_accepted,
+            "high_priority_review": summary.quality_check + summary.high,
+            "standard_review": summary.standard,
+            "remaining_unpredicted": remaining,
         }
 
     except Exception as e:

--- a/src/fafycat/api/ml.py
+++ b/src/fafycat/api/ml.py
@@ -30,7 +30,12 @@ from fafycat.core.database import AppSettingsORM, CategoryORM
 from fafycat.core.models import TransactionInput
 from fafycat.ml.categorizer import TransactionCategorizer
 from fafycat.ml.ensemble_categorizer import EnsembleCategorizer
-from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted, repredict_unreviewed
+from fafycat.ml.prediction_pipeline import (
+    CategorizationSummary,
+    get_auto_approve_threshold,
+    predict_unpredicted,
+    repredict_unreviewed,
+)
 
 router = APIRouter(prefix="/ml", tags=["ml"])
 
@@ -449,6 +454,28 @@ async def get_current_training_status() -> dict:
     return job.to_dict()
 
 
+def _batch_prediction_response(
+    summary: CategorizationSummary, remaining: int, *, empty_message: str, done_message: str, remaining_key: str
+) -> dict:
+    """Build the shared response shape for the batch prediction endpoints."""
+    if summary.total == 0:
+        return {
+            "status": "success",
+            "message": empty_message,
+            "predictions_made": 0,
+        }
+
+    return {
+        "status": "success",
+        "message": done_message,
+        "predictions_made": summary.total,
+        "auto_accepted": summary.auto_accepted,
+        "high_priority_review": summary.high_priority_review,
+        "standard_review": summary.standard,
+        remaining_key: remaining,
+    }
+
+
 @router.post("/predict/batch-unpredicted")
 async def predict_unpredicted_transactions(
     categorizer: TransactionCategorizer = Depends(get_categorizer),
@@ -458,24 +485,13 @@ async def predict_unpredicted_transactions(
     """Run ML predictions on transactions that don't have predictions yet."""
     try:
         summary, remaining = predict_unpredicted(db, categorizer, limit=limit)
-
-        if summary.total == 0:
-            return {
-                "status": "success",
-                "message": "No transactions need prediction",
-                "predictions_made": 0,
-            }
-
-        return {
-            "status": "success",
-            "message": f"Made predictions for {summary.total} transactions",
-            "predictions_made": summary.total,
-            "auto_accepted": summary.auto_accepted,
-            "high_priority_review": summary.quality_check + summary.high,
-            "standard_review": summary.standard,
-            "remaining_unpredicted": remaining,
-        }
-
+        return _batch_prediction_response(
+            summary,
+            remaining,
+            empty_message="No transactions need prediction",
+            done_message=f"Made predictions for {summary.total} transactions",
+            remaining_key="remaining_unpredicted",
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Batch prediction failed: {str(e)}") from e
 
@@ -489,23 +505,12 @@ async def repredict_unreviewed_transactions(
     """Re-run ML predictions on unreviewed transactions that already have predictions."""
     try:
         summary, remaining = repredict_unreviewed(db, categorizer, limit=limit)
-
-        if summary.total == 0:
-            return {
-                "status": "success",
-                "message": "No unreviewed transactions need re-prediction",
-                "predictions_made": 0,
-            }
-
-        return {
-            "status": "success",
-            "message": f"Re-predicted {summary.total} transactions",
-            "predictions_made": summary.total,
-            "auto_accepted": summary.auto_accepted,
-            "high_priority_review": summary.quality_check + summary.high,
-            "standard_review": summary.standard,
-            "remaining_unreviewed": remaining,
-        }
-
+        return _batch_prediction_response(
+            summary,
+            remaining,
+            empty_message="No unreviewed transactions need re-prediction",
+            done_message=f"Re-predicted {summary.total} transactions",
+            remaining_key="remaining_unreviewed",
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Batch re-prediction failed: {str(e)}") from e

--- a/src/fafycat/api/upload.py
+++ b/src/fafycat/api/upload.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from fafycat.api.dependencies import get_db_session
 from fafycat.api.models import UploadResponse
 from fafycat.data.csv_processor import CSVProcessor
-from fafycat.ml.prediction_pipeline import predict_new
+from fafycat.ml.prediction_pipeline import CategorizationSummary, predict_new
 
 router = APIRouter(prefix="/upload", tags=["upload"])
 
@@ -20,14 +20,19 @@ router = APIRouter(prefix="/upload", tags=["upload"])
 upload_sessions = {}
 
 
+def _summary_to_dict(summary: CategorizationSummary) -> dict:
+    """Map a Categorization Summary to the upload response fields."""
+    return {
+        "predictions_made": summary.total,
+        "auto_accepted": summary.auto_accepted,
+        "needs_review": summary.needs_review,
+        "quality_check": summary.quality_check,
+    }
+
+
 def empty_categorization_summary() -> dict:
     """Return a zeroed categorization summary."""
-    return {
-        "predictions_made": 0,
-        "auto_accepted": 0,
-        "needs_review": 0,
-        "quality_check": 0,
-    }
+    return _summary_to_dict(CategorizationSummary())
 
 
 def predict_transaction_categories(db: Session, transactions: list, new_count: int) -> dict:
@@ -48,12 +53,7 @@ def predict_transaction_categories(db: Session, transactions: list, new_count: i
         _handle_prediction_error(e)
         return empty_categorization_summary()
 
-    return {
-        "predictions_made": summary.total,
-        "auto_accepted": summary.auto_accepted,
-        "needs_review": summary.high + summary.standard,
-        "quality_check": summary.quality_check,
-    }
+    return _summary_to_dict(summary)
 
 
 def _handle_prediction_error(e: Exception):

--- a/src/fafycat/api/upload.py
+++ b/src/fafycat/api/upload.py
@@ -11,8 +11,8 @@ from sqlalchemy.orm import Session
 
 from fafycat.api.dependencies import get_db_session
 from fafycat.api.models import UploadResponse
-from fafycat.core.models import ReviewPriority
 from fafycat.data.csv_processor import CSVProcessor
+from fafycat.ml.prediction_pipeline import predict_new
 
 router = APIRouter(prefix="/upload", tags=["upload"])
 
@@ -31,122 +31,29 @@ def empty_categorization_summary() -> dict:
 
 
 def predict_transaction_categories(db: Session, transactions: list, new_count: int) -> dict:
-    """Predict categories for newly uploaded transactions with active learning selection."""
+    """Predict categories for newly imported transactions via the Prediction Pipeline.
+
+    Gracefully degrades to an empty categorization summary when no trained
+    Categorizer is available - the import itself still succeeds.
+    """
     if new_count <= 0:
         return empty_categorization_summary()
 
     try:
-        return _perform_predictions(db, transactions)
+        from fafycat.api.ml import get_categorizer
+
+        categorizer = get_categorizer(db)
+        summary = predict_new(db, categorizer, [t.generate_id() for t in transactions])
     except Exception as e:
         _handle_prediction_error(e)
         return empty_categorization_summary()
 
-
-def _perform_predictions(db: Session, transactions: list) -> dict:
-    """Perform ML predictions on transactions."""
-    from fafycat.api.ml import get_categorizer
-    from fafycat.core.database import TransactionORM
-
-    categorizer = get_categorizer(db)
-
-    # Get newly imported transactions for prediction
-    new_transaction_ids = [t.generate_id() for t in transactions]
-    new_txns = (
-        db.query(TransactionORM)
-        .filter(TransactionORM.id.in_(new_transaction_ids))
-        .filter(TransactionORM.predicted_category_id.is_(None))
-        .all()
-    )
-
-    if not new_txns:
-        return empty_categorization_summary()
-
-    # Convert and predict
-    txn_inputs = _convert_to_transaction_inputs(new_txns)
-    predictions = categorizer.predict_with_confidence(txn_inputs)
-
-    # Apply hybrid categorization strategy
-    return _apply_hybrid_categorization_strategy(db, new_txns, predictions)
-
-
-def _convert_to_transaction_inputs(new_txns):
-    """Convert ORM transactions to TransactionInput objects."""
-    from fafycat.core.models import TransactionInput
-
-    txn_inputs = []
-    for txn in new_txns:
-        txn_input = TransactionInput(
-            date=txn.date,
-            value_date=txn.value_date or txn.date,
-            name=txn.name,
-            purpose=txn.purpose or "",
-            amount=txn.amount,
-            currency=txn.currency,
-        )
-        txn_inputs.append(txn_input)
-    return txn_inputs
-
-
-def _apply_hybrid_categorization_strategy(db: Session, new_txns, predictions) -> dict:
-    """Apply hybrid categorization using confidence scores and active learning."""
-    from fafycat.core.models import TransactionPrediction
-    from fafycat.ml.active_learning import ActiveLearningSelector
-
-    # Get active learning strategic selections
-    al_selector = ActiveLearningSelector(db)
-    al_predictions = [
-        TransactionPrediction(
-            transaction_id=txn.id,
-            predicted_category_id=prediction.predicted_category_id,
-            confidence_score=prediction.confidence_score,
-            feature_contributions=prediction.feature_contributions,
-        )
-        for txn, prediction in zip(new_txns, predictions, strict=True)
-    ]
-
-    max_review_items = min(20, len(al_predictions))
-    strategic_selections = set(
-        al_selector.select_for_review(al_predictions, max_items=max_review_items, strategy="uncertainty")
-    )
-
-    # Apply categorization logic
-    from fafycat.api.ml import get_auto_approve_threshold
-
-    summary = empty_categorization_summary()
-    confidence_threshold = get_auto_approve_threshold(db)
-
-    for txn, prediction in zip(new_txns, predictions, strict=True):
-        bucket = _categorize_transaction(txn, prediction, strategic_selections, confidence_threshold)
-        summary["predictions_made"] += 1
-        summary[bucket] += 1
-
-    db.commit()
-    return summary
-
-
-def _categorize_transaction(txn, prediction, strategic_selections, confidence_threshold) -> str:
-    """Categorize a single transaction based on confidence and active learning flags.
-
-    Returns the bucket name: "auto_accepted", "quality_check", or "needs_review".
-    """
-    txn.predicted_category_id = prediction.predicted_category_id
-    txn.confidence_score = prediction.confidence_score
-
-    if prediction.confidence_score >= confidence_threshold:
-        if txn.id in strategic_selections:
-            # High confidence but flagged for quality check
-            txn.is_reviewed = False
-            txn.review_priority = ReviewPriority.QUALITY_CHECK
-            return "quality_check"
-        # High confidence and not flagged - auto accept
-        txn.category_id = prediction.predicted_category_id
-        txn.is_reviewed = True
-        txn.review_priority = ReviewPriority.AUTO_ACCEPTED
-        return "auto_accepted"
-    # Lower confidence - needs review
-    txn.is_reviewed = False
-    txn.review_priority = ReviewPriority.HIGH if txn.id in strategic_selections else ReviewPriority.STANDARD
-    return "needs_review"
+    return {
+        "predictions_made": summary.total,
+        "auto_accepted": summary.auto_accepted,
+        "needs_review": summary.high + summary.standard,
+        "quality_check": summary.quality_check,
+    }
 
 
 def _handle_prediction_error(e: Exception):

--- a/src/fafycat/ml/prediction_pipeline.py
+++ b/src/fafycat/ml/prediction_pipeline.py
@@ -5,6 +5,7 @@ Strategic Selection, Review Priority bucketing against the Auto-approve
 Threshold, and persists the outcome. Entry points commit before returning.
 """
 
+from collections import Counter
 from dataclasses import dataclass
 from datetime import date
 from typing import Protocol, cast
@@ -18,9 +19,6 @@ from .active_learning import ActiveLearningSelector
 
 MAX_REVIEW_ITEMS = 20
 """Cap on Strategic Selection review items per pipeline run."""
-
-DEFAULT_STRATEGY = "uncertainty"
-"""Default Strategic Selection strategy."""
 
 
 class ConfidenceCategorizer(Protocol):
@@ -43,6 +41,16 @@ class CategorizationSummary:
         """Number of transactions the run predicted."""
         return self.auto_accepted + self.quality_check + self.high + self.standard
 
+    @property
+    def high_priority_review(self) -> int:
+        """Transactions flagged for priority review (Strategic Selection buckets)."""
+        return self.quality_check + self.high
+
+    @property
+    def needs_review(self) -> int:
+        """Transactions below the Auto-approve Threshold awaiting review."""
+        return self.high + self.standard
+
 
 def get_auto_approve_threshold(db: Session) -> float:
     """Resolve the Auto-approve Threshold: DB setting with config fallback."""
@@ -61,7 +69,6 @@ def predict_unpredicted(
     *,
     limit: int = 1000,
     threshold: float | None = None,
-    strategy: str = DEFAULT_STRATEGY,
 ) -> tuple[CategorizationSummary, int]:
     """Predict transactions that have no Prediction yet.
 
@@ -70,7 +77,7 @@ def predict_unpredicted(
     """
     query = db.query(TransactionORM).filter(TransactionORM.predicted_category_id.is_(None))
     txns, remaining = _select_with_limit(query, limit)
-    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
+    return _apply_predictions(db, txns, categorizer, threshold=threshold), remaining
 
 
 def predict_new(
@@ -79,7 +86,6 @@ def predict_new(
     transaction_ids: list[str],
     *,
     threshold: float | None = None,
-    strategy: str = DEFAULT_STRATEGY,
 ) -> CategorizationSummary:
     """Predict newly imported transactions that are not yet predicted.
 
@@ -93,7 +99,7 @@ def predict_new(
         )
         .all()
     )
-    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy)
+    return _apply_predictions(db, txns, categorizer, threshold=threshold)
 
 
 def repredict_unreviewed(
@@ -102,7 +108,6 @@ def repredict_unreviewed(
     *,
     limit: int = 1000,
     threshold: float | None = None,
-    strategy: str = DEFAULT_STRATEGY,
 ) -> tuple[CategorizationSummary, int]:
     """Re-predict unreviewed transactions that already have a Prediction.
 
@@ -114,21 +119,15 @@ def repredict_unreviewed(
         TransactionORM.predicted_category_id.is_not(None),
     )
     txns, remaining = _select_with_limit(query, limit)
-    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
+    return _apply_predictions(db, txns, categorizer, threshold=threshold), remaining
 
 
 def _select_with_limit(query, limit: int) -> tuple[list[TransactionORM], int]:
-    """Fetch up to ``limit`` matches and count how many are left beyond it.
-
-    A failing selection query (e.g. missing table in a fresh database) is
-    treated as "nothing to predict" rather than an error.
-    """
-    try:
-        total_matching = query.count()
-        txns = query.limit(limit).all()
-    except Exception:
-        return [], 0
-    return txns, max(0, total_matching - len(txns))
+    """Fetch up to ``limit`` matches and count how many are left beyond it."""
+    txns = query.limit(limit).all()
+    if len(txns) < limit:
+        return txns, 0
+    return txns, max(0, query.count() - len(txns))
 
 
 def _to_input(txn: TransactionORM) -> TransactionInput:
@@ -148,7 +147,6 @@ def _apply_predictions(
     categorizer: ConfidenceCategorizer,
     *,
     threshold: float | None,
-    strategy: str,
 ) -> CategorizationSummary:
     """Predict, run Strategic Selection, bucket, persist, and commit."""
     if not txns:
@@ -168,17 +166,17 @@ def _apply_predictions(
     selector = ActiveLearningSelector(db)
     strategic_selections = set(
         selector.select_for_review(
-            al_predictions, max_items=min(MAX_REVIEW_ITEMS, len(al_predictions)), strategy=strategy
+            al_predictions, max_items=min(MAX_REVIEW_ITEMS, len(al_predictions)), strategy="uncertainty"
         )
     )
 
     if threshold is None:
         threshold = get_auto_approve_threshold(db)
 
-    counts = {priority: 0 for priority in ReviewPriority}
-    for txn, prediction in zip(txns, predictions, strict=True):
-        priority = _bucket_transaction(txn, prediction, strategic_selections, threshold)
-        counts[priority] += 1
+    counts = Counter(
+        _bucket_transaction(txn, prediction, strategic_selections, threshold)
+        for txn, prediction in zip(txns, predictions, strict=True)
+    )
 
     db.commit()
     return CategorizationSummary(
@@ -200,18 +198,12 @@ def _bucket_transaction(
     txn.confidence_score = prediction.confidence_score
 
     if prediction.confidence_score >= threshold:
-        if txn.id in strategic_selections:
-            txn.is_reviewed = False
-            txn.review_priority = ReviewPriority.QUALITY_CHECK
-            return ReviewPriority.QUALITY_CHECK
-        txn.category_id = prediction.predicted_category_id
-        txn.is_reviewed = True
-        txn.review_priority = ReviewPriority.AUTO_ACCEPTED
-        return ReviewPriority.AUTO_ACCEPTED
+        priority = ReviewPriority.QUALITY_CHECK if txn.id in strategic_selections else ReviewPriority.AUTO_ACCEPTED
+    else:
+        priority = ReviewPriority.HIGH if txn.id in strategic_selections else ReviewPriority.STANDARD
 
-    txn.is_reviewed = False
-    if txn.id in strategic_selections:
-        txn.review_priority = ReviewPriority.HIGH
-        return ReviewPriority.HIGH
-    txn.review_priority = ReviewPriority.STANDARD
-    return ReviewPriority.STANDARD
+    txn.review_priority = priority
+    txn.is_reviewed = priority is ReviewPriority.AUTO_ACCEPTED
+    if priority is ReviewPriority.AUTO_ACCEPTED:
+        txn.category_id = prediction.predicted_category_id
+    return priority

--- a/src/fafycat/ml/prediction_pipeline.py
+++ b/src/fafycat/ml/prediction_pipeline.py
@@ -73,6 +73,29 @@ def predict_unpredicted(
     return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
 
 
+def predict_new(
+    db: Session,
+    categorizer: ConfidenceCategorizer,
+    transaction_ids: list[str],
+    *,
+    threshold: float | None = None,
+    strategy: str = DEFAULT_STRATEGY,
+) -> CategorizationSummary:
+    """Predict newly imported transactions that are not yet predicted.
+
+    Returns the Categorization Summary. Commits.
+    """
+    txns = (
+        db.query(TransactionORM)
+        .filter(
+            TransactionORM.id.in_(transaction_ids),
+            TransactionORM.predicted_category_id.is_(None),
+        )
+        .all()
+    )
+    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy)
+
+
 def repredict_unreviewed(
     db: Session,
     categorizer: ConfidenceCategorizer,

--- a/src/fafycat/ml/prediction_pipeline.py
+++ b/src/fafycat/ml/prediction_pipeline.py
@@ -1,0 +1,173 @@
+"""Prediction Pipeline: one owner of prediction, Strategic Selection, and Review Priority.
+
+Takes stored transactions through prediction (via a passed-in Categorizer),
+Strategic Selection, Review Priority bucketing against the Auto-approve
+Threshold, and persists the outcome. Entry points commit before returning.
+"""
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Protocol, cast
+
+from sqlalchemy.orm import Session
+
+from ..core.config import AppConfig
+from ..core.database import AppSettingsORM, TransactionORM
+from ..core.models import ReviewPriority, TransactionInput, TransactionPrediction
+from .active_learning import ActiveLearningSelector
+
+MAX_REVIEW_ITEMS = 20
+"""Cap on Strategic Selection review items per pipeline run."""
+
+DEFAULT_STRATEGY = "uncertainty"
+"""Default Strategic Selection strategy."""
+
+
+class ConfidenceCategorizer(Protocol):
+    """The Categorizer seam: anything exposing confidence-scored prediction."""
+
+    def predict_with_confidence(self, transactions: list[TransactionInput]) -> list[TransactionPrediction]: ...
+
+
+@dataclass(frozen=True)
+class CategorizationSummary:
+    """Per-Review-Priority counts reported after one Prediction Pipeline run."""
+
+    auto_accepted: int = 0
+    quality_check: int = 0
+    high: int = 0
+    standard: int = 0
+
+    @property
+    def total(self) -> int:
+        """Number of transactions the run predicted."""
+        return self.auto_accepted + self.quality_check + self.high + self.standard
+
+
+def get_auto_approve_threshold(db: Session) -> float:
+    """Resolve the Auto-approve Threshold: DB setting with config fallback."""
+    try:
+        setting = db.query(AppSettingsORM).filter(AppSettingsORM.key == "auto_approve_threshold").first()
+        if setting and setting.value is not None:
+            return float(str(setting.value))
+    except Exception:
+        pass
+    return AppConfig().ml.auto_approve_threshold
+
+
+def predict_unpredicted(
+    db: Session,
+    categorizer: ConfidenceCategorizer,
+    *,
+    limit: int = 1000,
+    threshold: float | None = None,
+    strategy: str = DEFAULT_STRATEGY,
+) -> tuple[CategorizationSummary, int]:
+    """Predict transactions that have no Prediction yet.
+
+    Returns the Categorization Summary and the number of matching
+    transactions left unprocessed because of ``limit``. Commits.
+    """
+    query = db.query(TransactionORM).filter(TransactionORM.predicted_category_id.is_(None))
+    txns, remaining = _select_with_limit(query, limit)
+    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
+
+
+def _select_with_limit(query, limit: int) -> tuple[list[TransactionORM], int]:
+    """Fetch up to ``limit`` matches and count how many are left beyond it.
+
+    A failing selection query (e.g. missing table in a fresh database) is
+    treated as "nothing to predict" rather than an error.
+    """
+    try:
+        total_matching = query.count()
+        txns = query.limit(limit).all()
+    except Exception:
+        return [], 0
+    return txns, max(0, total_matching - len(txns))
+
+
+def _to_input(txn: TransactionORM) -> TransactionInput:
+    return TransactionInput(
+        date=cast(date, txn.date),
+        value_date=cast(date, txn.value_date or txn.date),
+        name=str(txn.name),
+        purpose=str(txn.purpose or ""),
+        amount=cast(float, txn.amount),
+        currency=str(txn.currency),
+    )
+
+
+def _apply_predictions(
+    db: Session,
+    txns: list[TransactionORM],
+    categorizer: ConfidenceCategorizer,
+    *,
+    threshold: float | None,
+    strategy: str,
+) -> CategorizationSummary:
+    """Predict, run Strategic Selection, bucket, persist, and commit."""
+    if not txns:
+        return CategorizationSummary()
+
+    predictions = categorizer.predict_with_confidence([_to_input(txn) for txn in txns])
+
+    al_predictions = [
+        TransactionPrediction(
+            transaction_id=str(txn.id),
+            predicted_category_id=prediction.predicted_category_id,
+            confidence_score=prediction.confidence_score,
+            feature_contributions=prediction.feature_contributions,
+        )
+        for txn, prediction in zip(txns, predictions, strict=True)
+    ]
+    selector = ActiveLearningSelector(db)
+    strategic_selections = set(
+        selector.select_for_review(
+            al_predictions, max_items=min(MAX_REVIEW_ITEMS, len(al_predictions)), strategy=strategy
+        )
+    )
+
+    if threshold is None:
+        threshold = get_auto_approve_threshold(db)
+
+    counts = {priority: 0 for priority in ReviewPriority}
+    for txn, prediction in zip(txns, predictions, strict=True):
+        priority = _bucket_transaction(txn, prediction, strategic_selections, threshold)
+        counts[priority] += 1
+
+    db.commit()
+    return CategorizationSummary(
+        auto_accepted=counts[ReviewPriority.AUTO_ACCEPTED],
+        quality_check=counts[ReviewPriority.QUALITY_CHECK],
+        high=counts[ReviewPriority.HIGH],
+        standard=counts[ReviewPriority.STANDARD],
+    )
+
+
+def _bucket_transaction(
+    txn: TransactionORM,
+    prediction: TransactionPrediction,
+    strategic_selections: set[str],
+    threshold: float,
+) -> ReviewPriority:
+    """Write one transaction's Prediction and Review Priority; return the bucket."""
+    txn.predicted_category_id = prediction.predicted_category_id
+    txn.confidence_score = prediction.confidence_score
+
+    if prediction.confidence_score >= threshold:
+        if txn.id in strategic_selections:
+            txn.is_reviewed = False
+            txn.review_priority = ReviewPriority.QUALITY_CHECK
+            return ReviewPriority.QUALITY_CHECK
+        txn.category_id = prediction.predicted_category_id
+        txn.is_reviewed = True
+        txn.review_priority = ReviewPriority.AUTO_ACCEPTED
+        return ReviewPriority.AUTO_ACCEPTED
+
+    txn.is_reviewed = False
+    if txn.id in strategic_selections:
+        txn.review_priority = ReviewPriority.HIGH
+        return ReviewPriority.HIGH
+    txn.review_priority = ReviewPriority.STANDARD
+    return ReviewPriority.STANDARD

--- a/src/fafycat/ml/prediction_pipeline.py
+++ b/src/fafycat/ml/prediction_pipeline.py
@@ -73,6 +73,27 @@ def predict_unpredicted(
     return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
 
 
+def repredict_unreviewed(
+    db: Session,
+    categorizer: ConfidenceCategorizer,
+    *,
+    limit: int = 1000,
+    threshold: float | None = None,
+    strategy: str = DEFAULT_STRATEGY,
+) -> tuple[CategorizationSummary, int]:
+    """Re-predict unreviewed transactions that already have a Prediction.
+
+    Returns the Categorization Summary and the number of matching
+    transactions left unprocessed because of ``limit``. Commits.
+    """
+    query = db.query(TransactionORM).filter(
+        TransactionORM.is_reviewed.is_(False),
+        TransactionORM.predicted_category_id.is_not(None),
+    )
+    txns, remaining = _select_with_limit(query, limit)
+    return _apply_predictions(db, txns, categorizer, threshold=threshold, strategy=strategy), remaining
+
+
 def _select_with_limit(query, limit: int) -> tuple[list[TransactionORM], int]:
     """Fetch up to ``limit`` matches and count how many are left beyond it.
 

--- a/tests/test_ml_api.py
+++ b/tests/test_ml_api.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from fafycat.core.database import Base, CategoryORM, TransactionORM
 from fafycat.core.models import TransactionPrediction
@@ -15,7 +16,12 @@ from fafycat.core.models import TransactionPrediction
 @pytest.fixture(scope="function")
 def shared_engine():
     """Create a shared database engine for tests."""
-    engine = create_engine("sqlite:///:memory:", echo=False, connect_args={"check_same_thread": False})
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     yield engine
     engine.dispose()
@@ -237,11 +243,11 @@ def test_predict_bulk_transactions(test_client):
 
     # Restaurant should be dining
     assert predictions[0]["predicted_category_id"] == 3
-    assert predictions[0]["predicted_category_name"] == "Unknown"  # DB lookup not available in test
+    assert predictions[0]["predicted_category_name"] == "dining"
 
     # Supermarket should be groceries
     assert predictions[1]["predicted_category_id"] == 1
-    assert predictions[1]["predicted_category_name"] == "Unknown"  # DB lookup not available in test
+    assert predictions[1]["predicted_category_name"] == "groceries"
 
 
 def test_predict_batch_unpredicted(test_client, test_db):

--- a/tests/test_prediction_pipeline.py
+++ b/tests/test_prediction_pipeline.py
@@ -19,7 +19,13 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from fafycat.core.database import AppSettingsORM, Base, CategoryORM, TransactionORM
 from fafycat.core.models import ReviewPriority, TransactionInput, TransactionPrediction
-from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted, repredict_unreviewed
+from fafycat.ml.prediction_pipeline import (
+    CategorizationSummary,
+    get_auto_approve_threshold,
+    predict_new,
+    predict_unpredicted,
+    repredict_unreviewed,
+)
 
 
 class FakeCategorizer:
@@ -257,3 +263,37 @@ def test_repredict_limit_and_remaining_unreviewed_rule(session: Session) -> None
 
     assert summary.total == 3
     assert remaining == 1
+
+
+def test_predict_new_selects_only_given_ids_without_predictions(session: Session) -> None:
+    """predict-new predicate: given ids AND not yet predicted; other rows untouched."""
+    txns = [
+        make_txn("new-a"),
+        make_txn("new-already-predicted", predicted_category_id=1, confidence_score=0.99),
+        make_txn("not-in-batch"),
+    ]
+    session.add_all(txns)
+    session.commit()
+
+    summary = predict_new(
+        session,
+        FakeCategorizer({"new-a": 0.60}),
+        transaction_ids=["id-new-a", "id-new-already-predicted"],
+        threshold=0.50,
+    )
+
+    assert summary.total == 1
+    assert summary.auto_accepted == 1
+    new_a, already_predicted, not_in_batch = txns
+    assert new_a.confidence_score == 0.60
+    assert isinstance(new_a.review_priority, ReviewPriority)
+    assert already_predicted.confidence_score == 0.99
+    assert not_in_batch.predicted_category_id is None
+
+
+def test_predict_new_with_no_matching_ids_returns_empty_summary(session: Session) -> None:
+    """No matching transactions -> empty Categorization Summary, no error."""
+    summary = predict_new(session, FakeCategorizer({}), transaction_ids=["missing"], threshold=0.50)
+
+    assert summary.total == 0
+    assert summary == CategorizationSummary()

--- a/tests/test_prediction_pipeline.py
+++ b/tests/test_prediction_pipeline.py
@@ -1,0 +1,224 @@
+"""Unit tests for the Prediction Pipeline module.
+
+Drives the entry-point verbs with a fake Categorizer (scripted confidence
+scores) on an in-memory database. The real Strategic Selection implementation
+is used, not mocked.
+
+Determinism note: ActiveLearningSelector's uncertainty strategy random-samples
+from the medium (0.7-0.9) and high (>0.9) confidence pools. All scripted
+scores stay below 0.7 so Strategic Selection deterministically picks the
+``int(0.7 * max_items)`` lowest-confidence transactions. Threshold overrides
+steer which Review Priority buckets those selections land in.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from fafycat.core.database import AppSettingsORM, Base, CategoryORM, TransactionORM
+from fafycat.core.models import ReviewPriority, TransactionInput, TransactionPrediction
+from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted
+
+
+class FakeCategorizer:
+    """Categorizer test double with scripted confidence scores keyed by transaction name."""
+
+    def __init__(self, scores_by_name: dict[str, float], predicted_category_id: int = 1):
+        self.scores_by_name = scores_by_name
+        self.predicted_category_id = predicted_category_id
+
+    def predict_with_confidence(self, transactions: list[TransactionInput]) -> list[TransactionPrediction]:
+        return [
+            TransactionPrediction(
+                transaction_id=txn.generate_id(),
+                predicted_category_id=self.predicted_category_id,
+                confidence_score=self.scores_by_name[txn.name],
+                feature_contributions={"merchant_name": 1.0},
+            )
+            for txn in transactions
+        ]
+
+
+@pytest.fixture
+def session() -> Session:
+    """In-memory database session that keeps python attribute state after commit."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    session = factory()
+    session.add(CategoryORM(id=1, name="groceries", type="spending", budget=0.0, is_active=True))
+    session.commit()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def make_txn(name: str, **overrides) -> TransactionORM:
+    defaults = dict(
+        id=f"id-{name}",
+        date=date(2024, 3, 1),
+        value_date=date(2024, 3, 1),
+        name=name,
+        purpose="purpose",
+        amount=-10.0,
+        currency="EUR",
+        category_id=None,
+        predicted_category_id=None,
+        confidence_score=None,
+        is_reviewed=False,
+        imported_at=datetime(2024, 3, 1, 12, 0),
+        import_batch="batch",
+    )
+    defaults.update(overrides)
+    return TransactionORM(**defaults)
+
+
+def test_predict_unpredicted_auto_accepts_confident_prediction(session: Session) -> None:
+    """A single high-confidence, unselected transaction is auto-accepted and persisted."""
+    txn = make_txn("solo")
+    session.add(txn)
+    session.commit()
+
+    # max_items=1: n_uncertain=int(0.7)=0, no medium/high pools below 0.7 -> nothing selected
+    categorizer = FakeCategorizer({"solo": 0.60})
+    summary, remaining = predict_unpredicted(session, categorizer, threshold=0.50)
+
+    assert summary.auto_accepted == 1
+    assert summary.total == 1
+    assert remaining == 0
+    assert txn.predicted_category_id == 1
+    assert txn.confidence_score == 0.60
+    assert txn.category_id == 1
+    assert txn.is_reviewed is True
+
+
+# With two transactions max_items=2 and n_uncertain=int(1.4)=1: exactly the
+# lowest-confidence transaction is strategically selected.
+BUCKETING_MATRIX = [
+    # (scores, threshold, expected buckets by name)
+    pytest.param(
+        {"low": 0.30, "confident": 0.60},
+        0.50,
+        {"low": "high", "confident": "auto_accepted"},
+        id="selected-below-threshold-is-high, unselected-at-or-above-auto-accepts",
+    ),
+    pytest.param(
+        {"low": 0.30, "mid": 0.40},
+        0.50,
+        {"low": "high", "mid": "standard"},
+        id="unselected-below-threshold-is-standard",
+    ),
+    pytest.param(
+        {"mid": 0.40, "confident": 0.60},
+        0.35,
+        {"mid": "quality_check", "confident": "auto_accepted"},
+        id="selected-at-or-above-threshold-is-quality-check",
+    ),
+]
+
+
+@pytest.mark.parametrize(("scores", "threshold", "expected"), BUCKETING_MATRIX)
+def test_bucketing_matrix(
+    session: Session, scores: dict[str, float], threshold: float, expected: dict[str, str]
+) -> None:
+    """All four Review Priority outcomes fall out of confidence x Strategic Selection."""
+    for name in scores:
+        session.add(make_txn(name))
+    session.commit()
+
+    summary, _ = predict_unpredicted(session, FakeCategorizer(scores), threshold=threshold)
+
+    by_name = {str(t.name): t for t in session.query(TransactionORM).all()}
+    for name, bucket in expected.items():
+        txn = by_name[name]
+        assert txn.review_priority == bucket, f"{name}: expected {bucket}, got {txn.review_priority}"
+        assert txn.is_reviewed is (bucket == "auto_accepted")
+
+    expected_counts = {bucket: list(expected.values()).count(bucket) for bucket in expected.values()}
+    for bucket, count in expected_counts.items():
+        assert getattr(summary, bucket) == count
+    assert summary.total == len(scores)
+
+
+def test_score_exactly_at_threshold_auto_accepts(session: Session) -> None:
+    """The threshold boundary is inclusive: score == threshold auto-accepts."""
+    session.add(make_txn("low"))
+    session.add(make_txn("boundary"))
+    session.commit()
+
+    summary, _ = predict_unpredicted(session, FakeCategorizer({"low": 0.30, "boundary": 0.50}), threshold=0.50)
+
+    assert summary.auto_accepted == 1
+    boundary = session.query(TransactionORM).filter(TransactionORM.name == "boundary").one()
+    assert boundary.review_priority == "auto_accepted"
+
+
+def test_persisted_review_priorities_are_enum_members(session: Session) -> None:
+    """Regression: the pipeline writes ReviewPriority enum members, not ad-hoc strings."""
+    scores = {"a": 0.30, "b": 0.40, "c": 0.45, "d": 0.60}
+    # Hold strong references: the session's identity map is weak, and a GC'd
+    # instance would be re-loaded from the DB as a plain string either way.
+    txns = [make_txn(name) for name in scores]
+    session.add_all(txns)
+    session.commit()
+
+    predict_unpredicted(session, FakeCategorizer(scores), threshold=0.50)
+
+    for txn in txns:
+        # expire_on_commit=False keeps the python objects the pipeline assigned
+        assert isinstance(txn.review_priority, ReviewPriority), (
+            f"{txn.name}: got {txn.review_priority!r} ({type(txn.review_priority).__name__})"
+        )
+    stored = [row[0] for row in session.query(TransactionORM.review_priority).all()]
+    valid_values = {member.value for member in ReviewPriority}
+    assert set(stored) <= valid_values
+
+
+def test_unpredicted_predicate_skips_transactions_with_predictions(session: Session) -> None:
+    """Only transactions without a Prediction are selected; existing Predictions are untouched."""
+    session.add(make_txn("fresh"))
+    session.add(make_txn("already-predicted", predicted_category_id=1, confidence_score=0.99))
+    session.commit()
+
+    summary, remaining = predict_unpredicted(session, FakeCategorizer({"fresh": 0.60}), threshold=0.50)
+
+    assert summary.total == 1
+    assert remaining == 0
+    untouched = session.query(TransactionORM).filter(TransactionORM.name == "already-predicted").one()
+    assert untouched.confidence_score == 0.99
+    assert untouched.review_priority == "standard"  # column default, never rewritten
+
+
+def test_limit_and_remaining_unpredicted_rule(session: Session) -> None:
+    """remaining = matching transactions beyond the limit; limited run predicts exactly `limit`."""
+    scores = {f"t{i}": 0.60 for i in range(5)}
+    for name in scores:
+        session.add(make_txn(name))
+    session.commit()
+
+    summary, remaining = predict_unpredicted(session, FakeCategorizer(scores), limit=3, threshold=0.50)
+
+    assert summary.total == 3
+    assert remaining == 2
+
+    summary2, remaining2 = predict_unpredicted(session, FakeCategorizer(scores), limit=3, threshold=0.50)
+    assert summary2.total == 2
+    assert remaining2 == 0
+
+
+def test_threshold_resolves_from_db_setting_when_not_overridden(session: Session) -> None:
+    """Without an override kwarg, the Auto-approve Threshold comes from the DB setting."""
+    session.add(AppSettingsORM(key="auto_approve_threshold", value="0.55"))
+    session.add(make_txn("just-below"))
+    session.add(make_txn("just-above"))
+    session.commit()
+
+    summary, _ = predict_unpredicted(session, FakeCategorizer({"just-below": 0.30, "just-above": 0.60}))
+
+    assert get_auto_approve_threshold(session) == 0.55
+    above = session.query(TransactionORM).filter(TransactionORM.name == "just-above").one()
+    assert above.review_priority == "auto_accepted"
+    below = session.query(TransactionORM).filter(TransactionORM.name == "just-below").one()
+    assert below.review_priority == "high"  # selected as the lowest-confidence item

--- a/tests/test_prediction_pipeline.py
+++ b/tests/test_prediction_pipeline.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from fafycat.core.database import AppSettingsORM, Base, CategoryORM, TransactionORM
 from fafycat.core.models import ReviewPriority, TransactionInput, TransactionPrediction
-from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted
+from fafycat.ml.prediction_pipeline import get_auto_approve_threshold, predict_unpredicted, repredict_unreviewed
 
 
 class FakeCategorizer:
@@ -222,3 +222,38 @@ def test_threshold_resolves_from_db_setting_when_not_overridden(session: Session
     assert above.review_priority == "auto_accepted"
     below = session.query(TransactionORM).filter(TransactionORM.name == "just-below").one()
     assert below.review_priority == "high"  # selected as the lowest-confidence item
+
+
+def test_repredict_selects_only_unreviewed_with_existing_prediction(session: Session) -> None:
+    """Re-predict predicate: unreviewed AND already has a Prediction; others untouched."""
+    txns = [
+        make_txn("unreviewed-predicted", predicted_category_id=1, confidence_score=0.30, is_reviewed=False),
+        make_txn("reviewed-predicted", predicted_category_id=1, confidence_score=0.30, is_reviewed=True),
+        make_txn("unreviewed-unpredicted", is_reviewed=False),
+    ]
+    session.add_all(txns)
+    session.commit()
+
+    summary, remaining = repredict_unreviewed(session, FakeCategorizer({"unreviewed-predicted": 0.60}), threshold=0.50)
+
+    assert summary.total == 1
+    assert summary.auto_accepted == 1
+    assert remaining == 0
+    target, reviewed, unpredicted = txns
+    assert target.confidence_score == 0.60
+    assert isinstance(target.review_priority, ReviewPriority)
+    assert reviewed.confidence_score == 0.30
+    assert unpredicted.predicted_category_id is None
+
+
+def test_repredict_limit_and_remaining_unreviewed_rule(session: Session) -> None:
+    """remaining counts unreviewed-with-Prediction matches beyond the limit."""
+    scores = {f"t{i}": 0.30 for i in range(4)}
+    txns = [make_txn(name, predicted_category_id=1, confidence_score=0.9) for name in scores]
+    session.add_all(txns)
+    session.commit()
+
+    summary, remaining = repredict_unreviewed(session, FakeCategorizer(scores), limit=3, threshold=0.50)
+
+    assert summary.total == 3
+    assert remaining == 1


### PR DESCRIPTION
## Summary

- Extract a single `ml/prediction_pipeline.py` module that owns prediction, Strategic Selection, Review Priority bucketing, and persistence (commits before returning)
- Migrate all three callers to it: `POST /predict/batch-unpredicted`, `POST /predict/batch-repredict`, and the CSV import path
- Three entry points: `predict_unpredicted`, `predict_new`, `repredict_unreviewed` — all thin wrappers over one shared `_apply_predictions` core, with a `ConfidenceCategorizer` protocol as the categorizer seam

## Cleanups (last commit)

- Drop unused `strategy` parameter threaded through every entry point
- Decide-first bucketing in `_bucket_transaction`; counts via `Counter`
- Skip the `count()` query when the fetch does not fill `limit` (was an unconditional second full-predicate scan per batch call)
- Remove catch-all guard that turned any selection-query DB error into a "nothing to predict" success response
- Derived review groupings (`high_priority_review`, `needs_review`) live on `CategorizationSummary` instead of being re-computed at call sites; batch endpoints share one response formatter
- Fix `test_ml_api` fixture: in-memory SQLite without `StaticPool` gave the TestClient thread its own empty database, which the removed guard had been masking

## Test plan

- New `tests/test_prediction_pipeline.py` covers bucketing matrix, threshold edge cases, selection filters, and limit/remaining accounting
- Full suite: 275 passed; ruff and ty clean