### PR TITLE
refactor: unify transaction-table rendering in one web component

### DIFF
--- a/src/fafycat/api/transactions.py
+++ b/src/fafycat/api/transactions.py
@@ -1,7 +1,6 @@
 """API routes for transaction operations."""
 
 import contextlib
-import html
 from datetime import date
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query
@@ -12,7 +11,7 @@ from fafycat.api.dependencies import get_db_session
 from fafycat.api.models import BulkApproveRequest, BulkCategorizeRequest, TransactionResponse, TransactionUpdate
 from fafycat.api.services import CategoryService, TransactionService
 from fafycat.core.models import ReviewPriority
-from fafycat.web.components.pagination import create_full_pagination
+from fafycat.web.components.transaction_table import render_row, render_table
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
@@ -84,54 +83,8 @@ async def categorize_transaction_htmx(
             status_code=404,
         )
 
-    # Generate updated table row
-    status_color = "text-success" if result.is_reviewed else "text-income"
-    status_text = "Complete" if result.is_reviewed else "Pending"
-    confidence_display = f"{result.confidence:.1%}" if result.confidence else "N/A"
-
-    # Get categories for the dropdown
     categories = CategoryService.get_categories(db)
-    category_options = '<option value="">Select category...</option>'
-    current_category = result.actual_category or result.predicted_category
-    for cat in categories:
-        selected = " selected" if cat.name == current_category else ""
-        escaped = html.escape(cat.name)
-        category_options += f'<option value="{escaped}"{selected}>{escaped}</option>'
-
-    return HTMLResponse(
-        content=f"""
-        <tr id="transaction-{transaction_id}">
-            <td>{result.date}</td>
-            <td>{html.escape(str(result.description))}</td>
-            <td class="amount-cell">${result.amount:,.2f}</td>
-            <td>
-                <span class="badge badge-success">
-                    {html.escape(str(result.actual_category))} ✓
-                </span>
-            </td>
-            <td>
-                <form hx-put="/api/transactions/{transaction_id}/categorize-htmx"
-                      hx-target="#transaction-{transaction_id}"
-                      hx-swap="outerHTML"
-                      hx-indicator="#loading-{transaction_id}"
-                      class="inline-form">
-                    <select name="actual_category" class="form-select">
-                        {category_options}
-                    </select>
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        Save
-                    </button>
-                    <div id="loading-{transaction_id}" class="htmx-indicator text-secondary">
-                        Saving...
-                    </div>
-                </form>
-            </td>
-            <td class="{status_color}">{status_text}</td>
-            <td class="text-center">{confidence_display}</td>
-        </tr>
-        """,
-        status_code=200,
-    )
+    return HTMLResponse(content=render_row(result, categories), status_code=200)
 
 
 @router.get("/table", response_class=HTMLResponse)
@@ -195,107 +148,7 @@ async def get_transactions_table(
 
     categories = CategoryService.get_categories(db)
 
-    return HTMLResponse(
-        content=_generate_transaction_table_htmx(result["transactions"], categories, result["pagination_info"])
-    )
-
-
-def _generate_transaction_table_htmx(transactions, categories, pagination_info=None):
-    """Generate HTMX-enhanced transaction table HTML."""
-    if not transactions:
-        return """
-        <div id="transaction-table" class="card">
-            <p class="text-center text-secondary" style="padding: 2rem 0">No transactions to review at the moment.</p>
-        </div>
-        """
-
-    # Generate table rows
-    table_rows = ""
-    for tx in transactions:
-        confidence_color = (
-            "text-spending"
-            if tx.confidence and tx.confidence < 0.5
-            else "text-income"
-            if tx.confidence and tx.confidence < 0.8
-            else "text-success"
-        )
-        confidence_display = f"{tx.confidence:.1%}" if tx.confidence else "N/A"
-
-        # Generate category options with current category selected
-        current_category = tx.actual_category or tx.predicted_category
-        category_options = '<option value="">Select category...</option>'
-        for cat in categories:
-            selected = " selected" if cat.name == current_category else ""
-            escaped = html.escape(cat.name)
-            category_options += f'<option value="{escaped}"{selected}>{escaped}</option>'
-
-        # Status display
-        status_color = "text-success" if tx.is_reviewed else "text-income"
-        status_text = "Complete" if tx.is_reviewed else "Pending"
-
-        table_rows += f"""
-        <tr id="transaction-{tx.id}">
-            <td>{tx.date}</td>
-            <td style="max-width: 24rem; overflow-wrap: anywhere; word-break: break-word;">{html.escape(str(tx.description))}</td>
-            <td class="amount-cell">${tx.amount:,.2f}</td>
-            <td>
-                <span class="badge badge-saving">
-                    {html.escape(str(tx.actual_category or tx.predicted_category or "Uncategorized"))}
-                </span>
-            </td>
-            <td style="min-width: 18rem;">
-                <form hx-put="/api/transactions/{tx.id}/categorize-htmx"
-                      hx-target="#transaction-{tx.id}"
-                      hx-swap="outerHTML"
-                      hx-indicator="#loading-{tx.id}"
-                      class="inline-form">
-                    <select name="actual_category" class="form-select">
-                        {category_options}
-                    </select>
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        Save
-                    </button>
-                    <div id="loading-{tx.id}" class="htmx-indicator text-secondary">
-                        Saving...
-                    </div>
-                </form>
-            </td>
-            <td class="{status_color}">{status_text}</td>
-            <td class="{confidence_color} font-medium text-center">{confidence_display}</td>
-        </tr>
-        """
-
-    # Generate pagination controls if pagination info is provided
-    pagination_html = ""
-    if pagination_info:
-        page = pagination_info["page"]
-        total_pages = pagination_info["total_pages"]
-        total_count = pagination_info["total_count"]
-
-        pagination_component = create_full_pagination(page, total_pages, total_count)
-        pagination_html = str(pagination_component)
-
-    return f"""
-    <div id="transaction-table" class="table-container">
-        <table>
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Description</th>
-                    <th style="text-align: right">Amount</th>
-                    <th>Current Category</th>
-                    <th>Categorize</th>
-                    <th>Status</th>
-                    <th style="text-align: center">Confidence</th>
-                </tr>
-            </thead>
-            <tbody>
-                {table_rows}
-            </tbody>
-        </table>
-        {pagination_html}
-    </div>
-    """
+    return HTMLResponse(content=render_table(result["transactions"], categories, result["pagination_info"]))
 
 
 @router.post("/bulk-categorize")

--- a/src/fafycat/web/components/transaction_table.py
+++ b/src/fafycat/web/components/transaction_table.py
@@ -1,0 +1,101 @@
+"""Transaction table renderer shared by the review page and HTMX endpoints."""
+
+from fasthtml.common import Button, Div, Form, Option, P, Select, Span, Table, Tbody, Td, Th, Thead, Tr, to_xml
+
+from fafycat.web.components.pagination import create_full_pagination
+
+
+def _category_select(tx, categories) -> Select:
+    """Category dropdown with the transaction's current category preselected."""
+    current = tx.actual_category or tx.predicted_category
+    options = [Option("Select category...", value="")]
+    for cat in categories:
+        options.append(Option(cat.name, value=cat.name, selected=cat.name == current))
+    return Select(*options, name="actual_category", cls="form-select")
+
+
+def _confidence_color(confidence: float | None) -> str:
+    if confidence and confidence < 0.5:
+        return "text-spending"
+    if confidence and confidence < 0.8:
+        return "text-income"
+    return "text-success"
+
+
+def _row(tx, categories) -> Tr:
+    """Build a transaction row with its HTMX categorization form."""
+    category_name = tx.actual_category or tx.predicted_category or "Uncategorized"
+    confidence_display = f"{tx.confidence:.1%}" if tx.confidence else "N/A"
+    if tx.is_reviewed:
+        badge = Span(f"{category_name} ✓", cls="badge badge-success")
+        status_text, status_color = "Complete", "text-success"
+    else:
+        badge = Span(category_name, cls="badge badge-saving")
+        status_text, status_color = "Pending", "text-income"
+
+    return Tr(
+        Td(str(tx.date)),
+        Td(
+            str(tx.description),
+            style="max-width: 24rem; overflow-wrap: anywhere; word-break: break-word;",
+        ),
+        Td(f"€{tx.amount:,.2f}", cls="amount-cell"),
+        Td(badge),
+        Td(
+            Form(
+                _category_select(tx, categories),
+                Button("Save", type="submit", cls="btn btn-primary btn-sm"),
+                Div("Saving...", id=f"loading-{tx.id}", cls="htmx-indicator text-secondary"),
+                hx_put=f"/api/transactions/{tx.id}/categorize-htmx",
+                hx_target=f"#transaction-{tx.id}",
+                hx_swap="outerHTML",
+                hx_indicator=f"#loading-{tx.id}",
+                cls="inline-form",
+            ),
+            style="min-width: 18rem;",
+        ),
+        Td(status_text, cls=status_color),
+        Td(confidence_display, cls=f"{_confidence_color(tx.confidence)} font-medium text-center"),
+        id=f"transaction-{tx.id}",
+    )
+
+
+def render_row(tx, categories) -> str:
+    """Render a single transaction row as an HTML fragment for HTMX swaps."""
+    return to_xml(_row(tx, categories))
+
+
+def render_table(transactions, categories, pagination_info=None) -> str:
+    """Render the full transaction table, or an empty-state card if there is nothing to review."""
+    if not transactions:
+        empty = Div(
+            P("No transactions to review at the moment.", cls="text-center text-secondary", style="padding: 2rem 0"),
+            id="transaction-table",
+            cls="card",
+        )
+        return to_xml(empty)
+
+    table = Table(
+        Thead(
+            Tr(
+                Th("Date"),
+                Th("Description"),
+                Th("Amount", style="text-align: right"),
+                Th("Current Category"),
+                Th("Categorize"),
+                Th("Status"),
+                Th("Confidence", style="text-align: center"),
+            )
+        ),
+        Tbody(*[_row(tx, categories) for tx in transactions]),
+    )
+
+    children = [table]
+    if pagination_info:
+        children.append(
+            create_full_pagination(
+                pagination_info["page"], pagination_info["total_pages"], pagination_info["total_count"]
+            )
+        )
+
+    return to_xml(Div(*children, id="transaction-table", cls="table-container"))

--- a/src/fafycat/web/components/transaction_table.py
+++ b/src/fafycat/web/components/transaction_table.py
@@ -1,6 +1,6 @@
 """Transaction table renderer shared by the review page and HTMX endpoints."""
 
-from fasthtml.common import Button, Div, Form, Option, P, Select, Span, Table, Tbody, Td, Th, Thead, Tr, to_xml
+from fasthtml.common import Button, Div, Form, NotStr, Option, P, Select, Span, Table, Tbody, Td, Th, Thead, Tr, to_xml
 
 from fafycat.web.components.pagination import create_full_pagination
 
@@ -8,7 +8,9 @@ from fafycat.web.components.pagination import create_full_pagination
 def _category_select(tx, categories) -> Select:
     """Category dropdown with the transaction's current category preselected."""
     current = tx.actual_category or tx.predicted_category
-    options = [Option("Select category...", value="")]
+    # NotStr keeps the empty value attribute — fastcore drops falsy attr values,
+    # and the placeholder must submit "" rather than its label text.
+    options = [Option("Select category...", value=NotStr(""))]
     for cat in categories:
         options.append(Option(cat.name, value=cat.name, selected=cat.name == current))
     return Select(*options, name="actual_category", cls="form-select")
@@ -50,6 +52,9 @@ def _row(tx, categories) -> Tr:
                 hx_target=f"#transaction-{tx.id}",
                 hx_swap="outerHTML",
                 hx_indicator=f"#loading-{tx.id}",
+                # FastHTML defaults Form to multipart/form-data; keep the
+                # urlencoded wire format the endpoint has always received.
+                enctype="application/x-www-form-urlencoded",
                 cls="inline-form",
             ),
             style="min-width: 18rem;",
@@ -94,7 +99,10 @@ def render_table(transactions, categories, pagination_info=None) -> str:
     if pagination_info:
         children.append(
             create_full_pagination(
-                pagination_info["page"], pagination_info["total_pages"], pagination_info["total_count"]
+                pagination_info["page"],
+                pagination_info["total_pages"],
+                pagination_info["total_count"],
+                per_page=pagination_info.get("page_size", 50),
             )
         )
 

--- a/src/fafycat/web/pages/review_page.py
+++ b/src/fafycat/web/pages/review_page.py
@@ -161,6 +161,7 @@ def render_review_page(request: Request):
         </div>
         """
         transaction_count = 0
+        categories = []
 
     # Get model status alert
     model_alert = _get_model_status_alert()

--- a/src/fafycat/web/pages/review_page.py
+++ b/src/fafycat/web/pages/review_page.py
@@ -7,6 +7,7 @@ from fastapi import Request
 from fafycat.api.dependencies import get_db_manager
 from fafycat.api.services import CategoryService, TransactionService
 from fafycat.web.components.layout import create_page_layout
+from fafycat.web.components.transaction_table import render_table
 
 
 def _get_model_status_alert():
@@ -127,95 +128,6 @@ def _generate_category_options(categories):
     return options
 
 
-def _generate_transaction_table(transactions, categories):
-    """Generate HTML table for transactions with HTMX enhancements."""
-    if not transactions:
-        return """
-        <div id="transaction-table" class="card">
-            <p class="text-center py-8">No transactions to review at the moment.</p>
-        </div>
-        """
-
-    # Generate table rows
-    table_rows = ""
-    for tx in transactions:
-        confidence_color = (
-            "text-error"
-            if tx.confidence and tx.confidence < 0.5
-            else "text-income"
-            if tx.confidence and tx.confidence < 0.8
-            else "text-success"
-        )
-        confidence_display = f"{tx.confidence:.1%}" if tx.confidence else "N/A"
-
-        # Generate category options with current category selected
-        current_category = tx.actual_category or tx.predicted_category
-        category_options = '<option value="">Select category...</option>'
-        for cat in categories:
-            escaped_cat = html.escape(cat.name)
-            selected = " selected" if cat.name == current_category else ""
-            category_options += f'<option value="{escaped_cat}"{selected}>{escaped_cat}</option>'
-
-        # Status display
-        status_color = "text-success" if tx.is_reviewed else "text-income"
-        status_text = "Complete" if tx.is_reviewed else "Pending"
-
-        table_rows += f"""
-        <tr id="transaction-{tx.id}">
-            <td class="px-4 py-3 text-sm">{tx.date}</td>
-            <td class="px-4 py-3 text-sm font-medium" style="max-width: 24rem; overflow-wrap: anywhere; word-break: break-word;">{html.escape(tx.description)}</td>
-            <td class="px-4 py-3 text-sm text-right">${tx.amount:,.2f}</td>
-            <td class="px-4 py-3 text-sm">
-                <span class="badge badge-neutral">
-                    {html.escape(tx.actual_category or tx.predicted_category or "Uncategorized")}
-                </span>
-            </td>
-            <td class="px-4 py-3 text-sm" style="min-width: 18rem;">
-                <form hx-put="/api/transactions/{tx.id}/categorize-htmx"
-                      hx-target="#transaction-{tx.id}"
-                      hx-swap="outerHTML"
-                      hx-indicator="#loading-{tx.id}"
-                      class="flex gap-2 items-center">
-                    <select name="actual_category" class="form-select">
-                        {category_options}
-                    </select>
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        Save
-                    </button>
-                    <div id="loading-{tx.id}" class="htmx-indicator text-xs">
-                        Saving...
-                    </div>
-                </form>
-            </td>
-            <td class="px-4 py-3 text-sm {status_color}">{status_text}</td>
-            <td class="px-4 py-3 text-sm {confidence_color} font-medium text-center">{confidence_display}</td>
-        </tr>
-        """
-
-    return f"""
-    <div id="transaction-table" class="table-container">
-        <div class="overflow-x-auto">
-            <table class="min-w-full">
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th>Description</th>
-                        <th>Amount</th>
-                        <th>Current Category</th>
-                        <th>Categorize</th>
-                        <th>Status</th>
-                        <th>Confidence</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {table_rows}
-                </tbody>
-            </table>
-        </div>
-    </div>
-    """
-
-
 def render_review_page(request: Request):
     """Render the review and categorize transactions page."""
     db_manager = get_db_manager(request)
@@ -237,12 +149,7 @@ def render_review_page(request: Request):
 
             categories = CategoryService.get_categories(session)
 
-            # Generate transaction table with pagination
-            from fafycat.api.transactions import _generate_transaction_table_htmx
-
-            transactions_html = _generate_transaction_table_htmx(
-                result["transactions"], categories, result["pagination_info"]
-            )
+            transactions_html = render_table(result["transactions"], categories, result["pagination_info"])
 
             transaction_count = result["pagination_info"]["total_count"]
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,17 @@
+"""Shared fake objects for rendering tests."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FakeTransaction:
+    """Minimal transaction-like object for rendering tests."""
+
+    id: str = "abc123"
+    date: str = "2025-06-15"
+    description: str = "Test Store"
+    amount: float = -10.0
+    actual_category: str | None = None
+    predicted_category: str | None = None
+    confidence: float | None = 0.75
+    is_reviewed: bool = False

--- a/tests/test_transaction_table.py
+++ b/tests/test_transaction_table.py
@@ -1,0 +1,199 @@
+"""Tests for the unified transaction-table renderer."""
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+from fafycat.core.database import CategoryORM, TransactionORM
+from fafycat.core.models import ReviewPriority
+
+
+@dataclass
+class FakeTransaction:
+    """Minimal transaction-like object for rendering tests."""
+
+    id: str = "abc123"
+    date: str = "2025-06-15"
+    description: str = "Test Store"
+    amount: float = -10.0
+    actual_category: str | None = None
+    predicted_category: str | None = None
+    confidence: float | None = 0.75
+    is_reviewed: bool = False
+
+
+def make_categories(*names: str) -> list[CategoryORM]:
+    return [CategoryORM(name=name, type="spending", budget=0.0) for name in names]
+
+
+class TestRenderRow:
+    def test_unreviewed_row_shows_pending_state(self):
+        from fafycat.web.components.transaction_table import render_row
+
+        tx = FakeTransaction(predicted_category="Groceries")
+        html = render_row(tx, make_categories("Groceries", "Rent"))
+
+        assert 'id="transaction-abc123"' in html
+        assert "Test Store" in html
+        assert "€-10.00" in html
+        assert "badge-saving" in html
+        assert "Groceries" in html
+        assert "Pending" in html
+        assert "✓" not in html
+
+    def test_reviewed_row_shows_confirmed_state(self):
+        from fafycat.web.components.transaction_table import render_row
+
+        tx = FakeTransaction(actual_category="Groceries", is_reviewed=True)
+        html = render_row(tx, make_categories("Groceries"))
+
+        assert "badge-success" in html
+        assert "✓" in html
+        assert "badge-saving" not in html
+        assert "Complete" in html
+        assert "text-success" in html
+
+    def test_row_escapes_description_and_category_names(self):
+        from fafycat.web.components.transaction_table import render_row
+
+        payload = "<img src=x onerror=alert(1)>"
+        tx = FakeTransaction(description=payload, predicted_category=payload)
+        html = render_row(tx, make_categories(payload))
+
+        assert payload not in html
+        assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+    def test_confidence_bands_color_the_confidence_cell(self):
+        from fafycat.web.components.transaction_table import render_row
+
+        categories = make_categories("Groceries")
+
+        low = render_row(FakeTransaction(confidence=0.3), categories)
+        assert "30.0%" in low
+        assert "text-spending" in low
+
+        mid = render_row(FakeTransaction(confidence=0.75), categories)
+        assert "75.0%" in mid
+        assert "text-income" in mid
+
+        high = render_row(FakeTransaction(confidence=0.9), categories)
+        assert "90.0%" in high
+        assert "text-success" in high
+
+        missing = render_row(FakeTransaction(confidence=None), categories)
+        assert "N/A" in missing
+
+    def test_row_form_targets_htmx_categorize_endpoint(self):
+        from fafycat.web.components.transaction_table import render_row
+
+        tx = FakeTransaction(id="tx42", predicted_category="Rent")
+        html = render_row(tx, make_categories("Groceries", "Rent"))
+
+        assert 'hx-put="/api/transactions/tx42/categorize-htmx"' in html
+        assert 'hx-target="#transaction-tx42"' in html
+        assert 'hx-swap="outerHTML"' in html
+        assert 'name="actual_category"' in html
+        assert '<option value="Rent" selected' in html
+        assert '<option value="Groceries" selected' not in html
+
+
+class TestRenderTable:
+    def test_empty_list_renders_empty_state_card(self):
+        from fafycat.web.components.transaction_table import render_table
+
+        html = render_table([], make_categories("Groceries"))
+
+        assert 'id="transaction-table"' in html
+        assert "No transactions to review" in html
+        assert "<table" not in html
+
+    def test_table_wraps_rows_with_headers(self):
+        from fafycat.web.components.transaction_table import render_table
+
+        transactions = [FakeTransaction(id="t1"), FakeTransaction(id="t2", is_reviewed=True)]
+        html = render_table(transactions, make_categories("Groceries"))
+
+        assert 'id="transaction-table"' in html
+        for header in ["Date", "Description", "Amount", "Current Category", "Categorize", "Status", "Confidence"]:
+            assert f"{header}</th>" in html
+        assert 'id="transaction-t1"' in html
+        assert 'id="transaction-t2"' in html
+        assert "pagination" not in html
+
+    def test_pagination_info_adds_pagination_controls(self):
+        from fafycat.web.components.transaction_table import render_table
+
+        html = render_table(
+            [FakeTransaction()],
+            make_categories("Groceries"),
+            pagination_info={"page": 2, "total_pages": 5, "total_count": 230},
+        )
+
+        assert "pagination-container" in html
+        assert "Page 2 of 5" in html
+        assert "230" in html
+
+
+def _seed_transaction(session, *, name: str = "REWE", amount: float = -42.50) -> tuple[TransactionORM, CategoryORM]:
+    """Insert one category and one unreviewed transaction predicted into it."""
+    cat = CategoryORM(name="Groceries", type="spending", budget=0.0)
+    session.add(cat)
+    session.flush()
+
+    txn_date = date(2025, 6, 15)
+    raw = f"{txn_date.isoformat()}|{name}|{amount:.2f}"
+    txn = TransactionORM(
+        id=hashlib.md5(raw.encode()).hexdigest()[:16],
+        date=txn_date,
+        name=name,
+        purpose="",
+        amount=amount,
+        currency="EUR",
+        predicted_category_id=cat.id,
+        confidence_score=0.6,
+        is_reviewed=False,
+        review_priority=ReviewPriority.HIGH,
+        import_batch="test-batch",
+        imported_at=datetime.now(UTC),
+    )
+    session.add(txn)
+    session.flush()
+    return txn, cat
+
+
+class TestEndpointsServeUnifiedMarkup:
+    def test_table_endpoint_uses_unified_renderer(self, test_client, db_session):
+        _seed_transaction(db_session)
+
+        resp = test_client.get("/api/transactions/table?status=all")
+
+        assert resp.status_code == 200
+        assert 'id="transaction-table"' in resp.text
+        assert "€-42.50" in resp.text
+        assert "$" not in resp.text
+
+    def test_categorize_htmx_returns_unified_row(self, test_client, db_session):
+        txn, cat = _seed_transaction(db_session)
+
+        resp = test_client.put(
+            f"/api/transactions/{txn.id}/categorize-htmx",
+            data={"actual_category": cat.name},
+        )
+
+        assert resp.status_code == 200
+        assert f'id="transaction-{txn.id}"' in resp.text
+        assert "badge-success" in resp.text
+        assert "✓" in resp.text
+        assert "€-42.50" in resp.text
+        # unified row keeps the table's cell styling (old fragment had drifted)
+        assert "max-width: 24rem" in resp.text
+
+    def test_review_page_uses_unified_renderer(self, test_client, db_session):
+        txn, _ = _seed_transaction(db_session)
+        db_session.commit()  # review page reads through its own session
+
+        resp = test_client.get("/review")
+
+        assert resp.status_code == 200
+        assert f'id="transaction-{txn.id}"' in resp.text
+        assert "€-42.50" in resp.text

--- a/tests/test_transaction_table.py
+++ b/tests/test_transaction_table.py
@@ -1,25 +1,11 @@
 """Tests for the unified transaction-table renderer."""
 
 import hashlib
-from dataclasses import dataclass
 from datetime import UTC, date, datetime
 
 from fafycat.core.database import CategoryORM, TransactionORM
 from fafycat.core.models import ReviewPriority
-
-
-@dataclass
-class FakeTransaction:
-    """Minimal transaction-like object for rendering tests."""
-
-    id: str = "abc123"
-    date: str = "2025-06-15"
-    description: str = "Test Store"
-    amount: float = -10.0
-    actual_category: str | None = None
-    predicted_category: str | None = None
-    confidence: float | None = 0.75
-    is_reviewed: bool = False
+from fakes import FakeTransaction
 
 
 def make_categories(*names: str) -> list[CategoryORM]:
@@ -96,6 +82,22 @@ class TestRenderRow:
         assert '<option value="Rent" selected' in html
         assert '<option value="Groceries" selected' not in html
 
+    def test_row_form_keeps_urlencoded_enctype(self):
+        """FastHTML defaults Form to multipart; the endpoint contract is urlencoded."""
+        from fafycat.web.components.transaction_table import render_row
+
+        html = render_row(FakeTransaction(), make_categories("Groceries"))
+
+        assert 'enctype="application/x-www-form-urlencoded"' in html
+
+    def test_placeholder_option_submits_empty_value(self):
+        """The placeholder must keep value="" so it never submits its label text."""
+        from fafycat.web.components.transaction_table import render_row
+
+        html = render_row(FakeTransaction(), make_categories("Groceries"))
+
+        assert '<option value="">Select category...</option>' in html
+
 
 class TestRenderTable:
     def test_empty_list_renders_empty_state_card(self):
@@ -126,12 +128,14 @@ class TestRenderTable:
         html = render_table(
             [FakeTransaction()],
             make_categories("Groceries"),
-            pagination_info={"page": 2, "total_pages": 5, "total_count": 230},
+            pagination_info={"page": 2, "total_pages": 3, "total_count": 230, "page_size": 100},
         )
 
         assert "pagination-container" in html
-        assert "Page 2 of 5" in html
+        assert "Page 2 of 3" in html
         assert "230" in html
+        # per_page comes from pagination_info, not the default of 50
+        assert "101" in html and "200" in html
 
 
 def _seed_transaction(session, *, name: str = "REWE", amount: float = -42.50) -> tuple[TransactionORM, CategoryORM]:

--- a/tests/test_xss_hardening.py
+++ b/tests/test_xss_hardening.py
@@ -1,28 +1,13 @@
 """Tests for XSS hardening across pages."""
 
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
 
 from fafycat.core.database import CategoryORM
-
+from fakes import FakeTransaction
 
 XSS_PAYLOAD = "<img src=x onerror=alert(1)>"
 XSS_ESCAPED = "&lt;img src=x onerror=alert(1)&gt;"
-
-
-@dataclass
-class _FakeTransaction:
-    """Minimal transaction-like object for rendering tests."""
-
-    id: str = "abc123"
-    date: str = "2025-06-15"
-    description: str = "Test Store"
-    amount: float = -10.0
-    actual_category: str | None = None
-    predicted_category: str | None = None
-    confidence: float | None = 0.75
-    is_reviewed: bool = False
 
 
 class TestUploadXSSEscaping:
@@ -79,7 +64,7 @@ class TestReviewPageXSS:
         from fafycat.web.components.transaction_table import render_table
 
         categories = [CategoryORM(name=XSS_PAYLOAD, type="spending", budget=0.0)]
-        transactions = [_FakeTransaction(predicted_category=XSS_PAYLOAD)]
+        transactions = [FakeTransaction(predicted_category=XSS_PAYLOAD)]
 
         html = render_table(transactions, categories)
 

--- a/tests/test_xss_hardening.py
+++ b/tests/test_xss_hardening.py
@@ -76,12 +76,12 @@ class TestReviewPageXSS:
 
     def test_transaction_table_escapes_category_name(self):
         """Category names in the transaction table badge are escaped."""
-        from fafycat.web.pages.review_page import _generate_transaction_table
+        from fafycat.web.components.transaction_table import render_table
 
         categories = [CategoryORM(name=XSS_PAYLOAD, type="spending", budget=0.0)]
         transactions = [_FakeTransaction(predicted_category=XSS_PAYLOAD)]
 
-        html = _generate_transaction_table(transactions, categories)
+        html = render_table(transactions, categories)
 
         assert XSS_PAYLOAD not in html
         assert XSS_ESCAPED in html


### PR DESCRIPTION
## Summary

Replaces three drifted copies of the transaction-table markup — the `GET /api/transactions/table` renderer, the `categorize-htmx` single-row fragment, and a dead copy in the review page — with one module: `src/fafycat/web/components/transaction_table.py` (`render_table` / `render_row`), built on FastHTML components so HTML escaping is structural instead of per-interpolation discipline.

Net: **-247 lines of duplicated markup**, and `web/pages` no longer reaches into a private `api` helper.

## Behavior changes (agreed in design review)

- Reviewed transactions show `badge-success` + ✓ consistently — previously only the post-save HTMX fragment showed it, and it vanished on reload
- Amounts render as EUR (`€`), matching the imported data, instead of `$`
- The post-save row keeps the table's cell styling (description max-width, confidence color) — previously drifted

## Tests

- New `tests/test_transaction_table.py`: 11 tests written TDD — row states (pending/reviewed), XSS escaping, confidence color bands, HTMX form wiring, empty state, pagination, plus integration tests for both endpoints and the review page
- `tests/test_xss_hardening.py` retargeted at the new module (was pinned to the deleted dead renderer)
- Full suite: 286 passed; ruff + ty clean (18 ty warnings preexisting on main)
- E2E smoke against the dev DB: review page and table endpoint serve unified markup

## Out of scope

- `web/pages`/`web/routes` still import `api.services`/`api.dependencies` (preexisting, unrelated to the renderer duplication)
- Pagination `hx_include` drops active filters — filed as #48

Generated with AI